### PR TITLE
Switching project type to Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
-language: ruby
-rvm:
-  - 2.4.1
+language: node_js
+node_js:
+  - 7.10.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
Otherwise we get too old a version of node.js and the firebase deployment
dependencies fail.