### PR TITLE
Feature: Support for YML & dynamic syntax highlighting for custom embed include

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,27 @@ If the PR fixes an issue, include the text "Fixes #XX" in the PR description, wh
 ### Oxford comma
 
 * Always use an Oxford comma.
+
+## Including code samples in posts
+
+### For non-yml files
+1. Place the code sample file into the `_files` directory
+2. Edit the code sample file and add yml frontmatter with a title key, for example: 
+   ```
+   ---
+   title: "filename.extension"
+   ---
+   ```
+3. In the post, use the below syntax to include the code sample.  The `title` param is *required* and needs to match the title key that was inserted in step 2. The `language` param is *optional* signifying what syntax highlighting language should be used.
+   `{% include files.html title="filename.extension" language="bash" %}`
+
+### For yml files
+1. Place the yml file into the `_ymls` directory
+2. Edit the yml file and add yml frontmatter with a title key, for example: 
+    ```
+    ---
+    title: "filename.yml"
+    ---
+   ```
+3. In the post, use the below syntax to include the yml file.  The `title` param is *required* and needs to match the title key that was inserted in step 2. The `language` param is also *required* and must be set to "yml"
+   `{% include files.html title="filename.yml" language="yml" %}`

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ collections:
   files:
     output: true
     permalink: /:collection/:path:output_ext
+  ymls:
+    output: true
+    permalink: /files/:path.yml
 defaults:
 - scope:
     path: ''

--- a/_includes/files.html
+++ b/_includes/files.html
@@ -7,22 +7,44 @@
   displayed inside a pre block and include a download link underneath.
 
   @param {string} "title" - the yml meta field for title in the download file
+  @param {string} "language" - the coding language used for syntax highlighting
 
 -->
 {% endcomment %}
 
+{% comment %}
+<!-- determine correct collection based on language param -->
+{% endcomment %}
+{% if include.language == "yml" or include.language == "yaml" %}
+	{% assign files = site.ymls | where: 'title', include.title %}
+{% else %}
+	{% assign files = site.files | where: 'title', include.title %}
+{% endif %}
 
-{% assign files = site.files | where: 'title', include.title %}
+{% comment %}
+<!-- determine syntax highlighting language.  Defaults to null -->
+{% endcomment %}
+{% assign lang_highlight = "" %}
+{% if include.language %}
+	{% assign lang_highlight = include.language %}
+{% endif %}
+
 {% for file in files %}
 
-  {% assign file_path = file.relative_path  | remove: '_files/' %}
+  {% comment %}
+  <!-- determine correct collection based on language param -->
+  {% endcomment %}
+  {% assign file_path = file.relative_path  | remove: '_files/'  | remove: '_ymls/' %}
+  {% if include.language == "yml" or include.language == "yaml" %}
+    {% assign file_path = file_path | append: "." | append: include.language %}
+  {% endif %}
   {% assign link = site.baseurl | append: '/files/' | append: file_path %}
 
-```bash
+```{{ lang_highlight }}
 {{ file.content }}
 ```
 <div class="wrapper">
-  <a href="{{ link }}" class="align-right">download raw</a>
+  <a href="{{ link }}" download class="align-right">download raw</a>
 </div>
 
 {% endfor %}

--- a/_ymls/sia-nextcloud/docker-compose
+++ b/_ymls/sia-nextcloud/docker-compose
@@ -1,0 +1,27 @@
+---
+title: docker-compose.yml
+---
+version: '3'
+volumes:
+  nextcloud-data:
+services:
+  sia:
+    build:
+      context: .
+      dockerfile: Dockerfile.sia
+    ports:
+      - "9980:9980"
+    volumes:
+      - ./sia-data:/mnt/sia-data
+      - ./sia-uploads:/mnt/sia-uploads
+  nextcloud:
+    build:
+      context: .
+      dockerfile: Dockerfile.nextcloud
+    ports:
+      - "8080:80"
+    links:
+      - sia:siad_container
+    volumes:
+      - ./sia-uploads:/mnt/sia-uploads
+      - nextcloud-data:/var/www/html


### PR DESCRIPTION
This PR fixes #100.  In addition, this PR fixes #101.  The solution for #100 HAD to include the solution for #101 and they are not mutually exclusive for this solution.

In order to solve the issue for supporting yml files to be embedded within a post AS WELL AS downloadable as a yml file by an end user, the following was done:

A new Jekyll collection called "ymls" whose files are located in `_ymls` was created.  This collection is ONLY for yml files to be included within posts.  It works the exact same way as the "files" collection created in #98 however, what makes it different is its handling of how it is stored and then generated as detailed below.

- the "files" collection should include any and all files that are included within posts, with the exception of yml files, due to the special significance yml has for Jekyll.  The files collection will generate the files as is minus the yml frontmatter that is at the top of the file.
- the "ymls" collection should contain ONLY yml files that can not be include in "files" due to the special significance of yml for Jekyll.  The ymls collection will generate the files with a ".yml" extension.  That is really the only difference, but it allows support for yml files to do what we need to solve #100.
- in order to include yml files in posts, it uses the same liquid include syntax as the files collection includes, however, it *must* include the `language="yml"` parameter in the include as the logic keys on that parameter and checks if the language is yml in order to properly include it from the correct collection.

### What I like about this solution:
- It's native to Jekyll functionality
- We don't have to complicate build/deploy scripts by changing extensions and editing already generated html risking a bug of some sort
- It follows a similar methodology already used in #98.

### What I don't like about this solution:
- It adds another directory `_ymls` to the root for the Jekyll collection
- It separates out common functionality/storage which can add to complexity down the road

### Other minor notes in this PR:
- I added a "download" attribute to the "download raw" link in order to force the browser to actually download the file when clicked.  For yml files when I clicked a link in some browsers it just opened the yml file within the browser.  Adding the attribute forced the file to download.  Hope that is desired?  If not, we can remove the download attribute and let the browser decide how to handle.
- The syntax highlighting language will now default to null or raw triple backtick per #101 , unless the language parameter is stated in the include statement.
- I also kept one file in the `_ymls/` directory so the commit would keep the directory included in the commit and you wouldn't have to add that directory when you do add in yml files.  When this PR is merged, the yml file will be built into the `_site` dir but since it is not being linked anywhere in this commit/branch yet, that should be okay.

### Instructions for including code examples in posts

#### Non-yml files (doesn't have a `.yml` file extension)
1. place the code example file into the `_files` directory
2. edit the code example and add yml frontmatter with a title key, for example: 
    ```
    ---
    title: "filename.extension"
    ---
   ```
3. use the below syntax to include within a post with the `title` param *required* and matching the code example file's yml key for `title` and the `language` param *optional* signifying syntax highlighting language to be used:
    `{% include files.html title="filename.extension" language="bash" %}`

#### yml files
1. place example yml file into the `_ymls` directory
2. edit the example yml file adding yml frontmatter with a title key, for example: 
    ```
    ---
    title: "filename.yml"
    ---
   ```
3. use the below syntax to include within a post with the `title` param *required* and matching the code example file's yml key for `title` and the `language` param *required* and must be set to "yml":
    `{% include files.html title="filename.yml" language="yml" %}`

