### PR TITLE
Feature: Adding header hover link capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 before_install:
   - nvm install 7.10.0
+  - npm install
+  - npm run build:js
 script:
   - ./_tests/build
 before_deploy:

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,8 +6,6 @@
 
 @import "minimal-mistakes";
 
-$screen-sm: 768px;
-
 @font-face {
   font-family: "anchor-icon";
   font-style: normal;
@@ -32,21 +30,21 @@ $screen-sm: 768px;
   text-decoration: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  position: absolute;
-  margin-left: -20px;
-  font-size: 24px;
+  float: left;
+  margin-left: -16px;
   line-height: 100%;
-  top: 50%;
-  transform: translateY(-50%);
 
   &:after {
     content: attr(data-icon);
   }
 
-  @media screen and (max-width: $screen-sm) {
-    margin-left: -13px;
-    font-size: 18px;
+  @include breakpoint($large) {
+    margin-left: -25px;
   }
+}
+
+.page__content a.anchor-link {
+  text-decoration: none;
 }
 
 *:hover  > .anchor-link {

--- a/assets/js/_anchors.js
+++ b/assets/js/_anchors.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview This file houses functionality developed externally from the
+ * theme's javascript files.  It is compiled and included in the site's
+ * main.min.js
+ */
+
+// Adding IIFE for variables scoping
+(() => {
+  const _anchors = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+
+  // Add anchor permalinks to any Header tag that has an id
+  // Iterate over each header in array
+  [..._anchors].forEach(anchor => {
+
+    // If this header has an 'ID' attribute
+    if (anchor.id) {
+
+      // Create new link element, add attributes, and append it to the header.
+      const link = document.createElement('a');
+      link.dataset.icon = '';
+      link.classList.add('anchor-link');
+      link.href = `#${anchor.id}`;
+      anchor.insertBefore(link, anchor.firstChild);
+    }
+  });
+})();
+
+// enables hashtag relocation on in-page anchor links
+$(window).bind('hashchange', event => {
+  $.smoothScroll({
+    // Replace '#/' with '#' to go to the correct target and after scrolling
+    scrollTarget: location.hash.replace(/^\#\/?/, '#'),
+    afterScroll(options) {
+      location.hash = location.hash.replace(/^\#\/?/, '#');
+    }
+  });
+});
+
+$('a[href*="#"]').bind('click', function(event) {
+  // Remove '#' from the hash.
+  let hash = this.hash.replace(/^#/, '');
+
+  if (this.pathname === location.pathname && hash) {
+    event.preventDefault();
+
+    // Change '#' (removed above) to '#/' so it doesn't jump without the smooth scrolling
+    location.hash = `#/${hash}`;
+  }
+});
+
+// Trigger hashchange event on page load if there is a hash in the URL.
+if (location.hash) {
+  $(window).trigger('hashchange');
+}

--- a/assets/js/_anchors.js
+++ b/assets/js/_anchors.js
@@ -4,47 +4,48 @@
  * main.min.js
  */
 
-// Adding IIFE for variables scoping
-(() => {
-  const _anchors = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+(function() {
+  const _anchors = $('h1, h2, h3, h4, h5, h6');
 
-  // Add anchor permalinks to any Header tag that has an id
-  // Iterate over each header in array
-  [..._anchors].forEach(anchor => {
-
-    // If this header has an 'ID' attribute
-    if (anchor.id) {
-
-      // Create new link element, add attributes, and append it to the header.
-      const link = document.createElement('a');
-      link.dataset.icon = '';
-      link.classList.add('anchor-link');
-      link.href = `#${anchor.id}`;
-      anchor.insertBefore(link, anchor.firstChild);
+  //adds anchor permalinks to any Header tag that has an id
+  $(_anchors).each(function (i, el) {
+    var $el, id, permalink;
+    $el = $(el);
+    id = $el.attr('id');
+    if (id) {
+      if ( $('#blog-nav-page').length ) {
+        permalink = $('.blog-entry').attr('id') + "#" + id;
+      } else {
+        permalink = "#" + id
+      }
+      return $el.prepend($("<a />").addClass("anchor-link")
+        .attr("href", permalink).attr("data-icon", ""));
     }
   });
 })();
 
 // enables hashtag relocation on in-page anchor links
-$(window).bind('hashchange', event => {
+$(window).bind('hashchange', function(event) {
   $.smoothScroll({
-    // Replace '#/' with '#' to go to the correct target and after scrolling
+    // Replace '#/' with '#' to go to the correct target and after scrollin
     scrollTarget: location.hash.replace(/^\#\/?/, '#'),
-    afterScroll(options) {
+    afterScroll: function() {
       location.hash = location.hash.replace(/^\#\/?/, '#');
     }
   });
 });
 
-$('a[href*="#"]').bind('click', function(event) {
+$('a[href*="#"]')
+.bind('click', function(event) {
   // Remove '#' from the hash.
-  let hash = this.hash.replace(/^#/, '');
+  var hash = this.hash.replace(/^#/, '')
 
   if (this.pathname === location.pathname && hash) {
     event.preventDefault();
 
-    // Change '#' (removed above) to '#/' so it doesn't jump without the smooth scrolling
-    location.hash = `#/${hash}`;
+    // Change '#' (removed above) to '#/' so it doesn't jump without the smooth
+    // scrolling
+    location.hash = '#/' + hash;
   }
 });
 

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -1,20 +1,72 @@
-// Adding IIFE for variables scoping
-(() => {
-  const _anchors = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+/* ==========================================================================
+   jQuery plugin settings and other scripts
+   ========================================================================== */
 
-  // Add anchor permalinks to any Header tag that has an id
-  // Iterate over each header in array
-  [..._anchors].forEach(anchor => {
+$(document).ready(function(){
 
-    // If this header has an 'ID' attrbiute
-    if (anchor.id) {
+  // Sticky footer
+  var bumpIt = function() {
+      $('body').css('margin-bottom', $('.page__footer').outerHeight(true));
+    },
+    didResize = false;
 
-      // Create new link element, add attrbiutes and append it to the beggining or the header.
-      const link = document.createElement('a');
-      link.dataset.icon = '';
-      link.classList.add('anchor-link');
-      link.href = `#${anchor.id}`;
-      anchor.insertBefore(link, anchor.firstChild);
-    }
+  bumpIt();
+
+  $(window).resize(function() {
+    didResize = true;
   });
-})();
+  setInterval(function() {
+    if(didResize) {
+      didResize = false;
+      bumpIt();
+    }
+  }, 250);
+
+  // FitVids init
+  $("#main").fitVids();
+
+  // Follow menu drop down
+  $(".author__urls-wrapper button").on("click", function() {
+    $(".author__urls").fadeToggle("fast", function() {});
+    $(".author__urls-wrapper button").toggleClass("open");
+  });
+
+  // init smooth scroll
+  $("a").smoothScroll({offset: -20});
+
+  // add lightbox class to all image links
+  $("a[href$='.jpg'],a[href$='.jpeg'],a[href$='.JPG'],a[href$='.png'],a[href$='.gif']").addClass("image-popup");
+
+  // Magnific-Popup options
+  $(".image-popup").magnificPopup({
+    // disableOn: function() {
+    //   if( $(window).width() < 500 ) {
+    //     return false;
+    //   }
+    //   return true;
+    // },
+    type: 'image',
+    tLoading: 'Loading image #%curr%...',
+    gallery: {
+      enabled: true,
+      navigateByImgClick: true,
+      preload: [0,1] // Will preload 0 - before current, and 1 after the current image
+    },
+    image: {
+      tError: '<a href="%url%">Image #%curr%</a> could not be loaded.',
+    },
+    removalDelay: 500, // Delay in milliseconds before popup is removed
+    // Class that is added to body when popup is open.
+    // make it unique to apply your CSS animations just to this exact popup
+    mainClass: 'mfp-zoom-in',
+    callbacks: {
+      beforeOpen: function() {
+        // just a hack that adds mfp-anim class to markup
+        this.st.image.markup = this.st.image.markup.replace('mfp-figure', 'mfp-figure mfp-with-anim');
+      }
+    },
+    closeOnContentClick: true,
+    midClick: true // allow opening popup on middle mouse click. Always set it to true if you don't provide alternative source.
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimal-mistakes",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "description": "Minimal Mistakes Jekyll theme npm build scripts",
   "repository": {
     "type": "git",
@@ -21,16 +21,13 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
     "npm-run-all": "^1.7.0",
     "onchange": "^2.2.0",
     "uglify-js": "^2.6.1"
   },
   "scripts": {
-    "babel": "babel assets/js/_anchors.js --out-file assets/js/script-compiled.js",
-    "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.4.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/_main.js assets/js/script-compiled.js -c -m -o assets/js/main.min.js",
+    "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.4.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/_main.js assets/js/_anchors.js -c -m -o assets/js/main.min.js",
     "watch:js": "onchange \"assets/js/**/*.js\" -e \"assets/js/main.min.js\" -- npm run build:js",
-    "build:js": "npm run babel && npm run uglify"
+    "build:js": "npm run uglify"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimal-mistakes",
-  "version": "3.4.4",
+  "version": "4.4.2",
   "description": "Minimal Mistakes Jekyll theme npm build scripts",
   "repository": {
     "type": "git",
@@ -28,8 +28,8 @@
     "uglify-js": "^2.6.1"
   },
   "scripts": {
-    "babel": "babel assets/js/_main.js --out-file assets/js/script-compiled.js",
-    "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.4.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/script-compiled.js -c -m -o assets/js/main.min.js",
+    "babel": "babel assets/js/_anchors.js --out-file assets/js/script-compiled.js",
+    "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.4.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/_main.js assets/js/script-compiled.js -c -m -o assets/js/main.min.js",
     "watch:js": "onchange \"assets/js/**/*.js\" -e \"assets/js/main.min.js\" -- npm run build:js",
     "build:js": "npm run babel && npm run uglify"
   }

--- a/script/_serve_dev.sh
+++ b/script/_serve_dev.sh
@@ -1,1 +1,10 @@
+#!/bin/bash
+
+# terminate the script if any command fails
+set -e
+
+# Run JS build task
+npm run build:js
+
+# Start jekyll server
 bundle exec jekyll serve --config _config.yml,_config_dev.yml --watch


### PR DESCRIPTION
Fixes #92 

This PR is the easiest solution for adding the header hover link capability into the site.  This solution called for customizing the base Jekyll theme and seems like how it was intended to work from previous pull requests.

### Solution description

Adding the header hover links requires js to enable the GFM links that appear to the left of headers.  Due to the need of additional js to accomplish the task, we need a way to get the custom js into main.min.js which the site calls, therefore the build task is modified.  However, because we need to rebuild the js, we need to store all of the js from the base Jekyll theme in this local repo.  This may not be ideal from an updating gem perspective, but it is the quickest solution without having the site all additional js files.  Other options to avoid doing that are listed in "Other possible solutions to consider" below.
- [X] Extended the js capability by creating a separate js file (`assets/js/_anchors.js`) to house the anchor link capability.  Previous attempts at doing this completely over-rode the theme's default `_main.js` file so that is the reason for other functionality breaking like the image popups and incorrect styling issues with the sign-up form, etc.  The `assets/js/_main.js` file is copied directly from the theme (as it was for version 4.4.2 -- it has changed in newer versions of the theme's gem) without any modifications.

- [X] Added a feature which I believe is desired when clicking a hover link actually changing the url hash so it can be copy/pasted/linked.  Because of the base theme's implementation of JQuery smoothScroll, I had to override that plugin with how in-page anchors treat the hash.

- [X] Updated the `build:js` job in `package.json` to re-compile `main.min.js`.  Also updated the version of package.json to match the theme's gem being used.

- [X] Modified the build step in the `before_install` section of `.travis.yml` to re-compile the `main.min.js` file.  Also modified the development build script to include re-compiling the js just like revised previous attempts did.

- [X] Tested in Mac Chrome, FF, & Safari and several browser widths and Chrome's device emulator.  Having a hard time testing on a true mobile device and windows since the base theme uses absolute urls everywhere.

- [X] Tweaked the styling a bit as I saw issues with how the link was showing for different header types (h1, h2, h3, etc.).  I personally felt this styling looked better, but certainly happy to revert to previous styling if desired.

### Considerations in this solution

- [X] Previous attempts for this solution included es6 syntax for the js.  Keeping it like this is fine, however, that is the only es6 being used in the site/theme, so including babel dependencies for a comparatively small piece of the entire puzzle may want to be evaluated.  If there are future plans to use es6 more extensively, then maybe it makes sense to leave.

### Other possible solutions to consider
As mentioned previously, I'm not a big fan of copying all the js from the base theme when thinking about upgrading the gem to newer versions.  Overrides should be kept to a minimum in my opinion and limited to specially designated files.  I'm also not sure how often we need to upgrade the theme's gem in this site, but that's the whole point of using a gem.  Unfortunately, I couldn't come up with a solution where the site still had a single js file to load for this to work.
1. Another option, could be to build any custom js that we do on our end into its own js file and have the site load 2 js files?  I know best practice says to avoid that if at all possible for performance reasons, however, maybe this might be an exception to explore.
2. Along the same lines, I suppose we could inject a separate compiled js into an include/layout so the js is inlined, however, I feel the most efficient way of doing that is again overriding the theme.  So, I'd rather go with a separate js file, but mentioning it as a possibility.
3. I could also explore (not 100% positive this will work...) re-compiling the js post-build, but my concern is we wouldn't be able to have the js build in the `before_install` section in travis as it stands today. But would you be amenable to moving the Jekyll build to the `before_install`?  Or moving both commands to a `script` section?  
3. I also noticed in the theme's repo a request for adding in anchorjs and code was even submitted showing how.  Maybe in a future version of this theme, this functionality might exist in the base theme and we can remove/alter this solution if/when that is implemented.
