### PR TITLE
Make "Reddit" lowercase in sidebar

### DIFF
--- a/_includes/author-profile-custom-links.html
+++ b/_includes/author-profile-custom-links.html
@@ -1,5 +1,5 @@
 <li>
   <a href="https://www.reddit.com/user/mtlynch/submitted">
-    <i class="fa fa-fw fa-reddit" aria-hidden="true"></i> Reddit
+    <i class="fa fa-fw fa-reddit" aria-hidden="true"></i> reddit
   </a>
 </li>


### PR DESCRIPTION
Fixes #89 

This PR is a minor update to change "Reddit" in the sidebar author profile to lowercase, "reddit".  The solution with this PR is the simple approach by simply changing the text to all lowercase.

Is it desired to add a css text transform style to ensure it stays lowercase as well?  I can see where it would be helpful if all links in the sidebar were lowercase or if that in particular link changed often, but I think the simple text change is probably enough for this to not add unnecessary css classes?