### PR TITLE
Removing leading zero for the day part of article dates

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -31,7 +31,7 @@
       {% endif %}
     </h2>
     {% if post.date %}
-      <p class="page__date">{{ post.date | date: "%B %d, %Y" }}</p>
+      <p class="page__date">{{ post.date | date: "%B %-d, %Y" }}</p>
     {% endif %}
     {% if post.read_time %}
       <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -20,15 +20,15 @@ layout: default
   <article class="page" itemscope itemtype="http://schema.org/CreativeWork">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
-    {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date: "%B %d, %Y" }}">{% endif %}
-    {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date: "%B %d, %Y" }}">{% endif %}
+    {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date: "%B %-d, %Y" }}">{% endif %}
+    {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date: "%B %-d, %Y" }}">{% endif %}
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
           {% if page.title %}<h1 class="page__title" itemprop="headline">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</h1>{% endif %}
           {% if page.date %}
-            <p class="page__date">{{ page.date | date: "%B %d, %Y" }}</p>
+            <p class="page__date">{{ page.date | date: "%B %-d, %Y" }}</p>
           {% endif %}
           {% if page.read_time %}
             <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
@@ -50,9 +50,9 @@ layout: default
         {% endif %}
         {% include page__taxonomy.html %}
         {% if page.last_modified_at %}
-          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%B %d, %Y" }}</time></p>
+          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%-d" }}">{{ page.last_modified_at | date: "%B %-d, %Y" }}</time></p>
         {% elsif page.date %}
-          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time></p>
+          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time></p>
         {% endif %}
       </footer>
 


### PR DESCRIPTION
This PR fixes #96.

In order to remove leading zeros from the day part of article dates, we need to tweak the date formatting slightly from `%d` for dates to `%-d` to signify no leading zeros. 
 
- [X] I ended up doing a search and replace across the site to ensure the date formatting is changed consistently across any dates.
- [X] I verified that dates on the article index page, individual article pages, as well as the "related posts" section are all no longer showing leading zeros in dates.

**Please note** - The theme does have the `%d` date format inside some of its other layouts that are not currently being used in the site.  Therefore, if other layouts are utilized within the site, we may need to alter the date formats in those other layouts.  I would not recommend pulling those other layouts down into the site at this moment simply to change the date formats as I don't think there are any plans to utilize any of the other layouts.  If you feel differently, we can do that though.
