### PR TITLE
Bug: Fixing "download raw" link alignment issues

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -43,8 +43,8 @@
 ```{{ lang_highlight }}
 {{ file.content }}
 ```
-<div class="wrapper">
-  <a href="{{ link }}" download class="align-right">download raw</a>
+<div class="clearfix">
+  <a href="{{ link }}" download class="align-right btn--small">download raw</a>
 </div>
 
 {% endfor %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -112,3 +112,13 @@ figure {
     }
   }
 }
+
+// More robust clearfix class than what is in theme
+.clearfix:after {
+  visibility: hidden;
+  display: block;
+  font-size: 0;
+  content: " ";
+  clear: both;
+  height: 0;
+}


### PR DESCRIPTION
This PR fixes #111 .

## Solution
The solution for this issue includes 2 key changes:
- [X] Add a proper "clearfix" class to the site that can be used to properly clear floats without adding extraneous divs.  This piece fixes the text wrapping part of the issue.
- [X] Added a "btn--small" class to the link to try and reduce vertical space.  If this isn't enough, we can look at reducing padding, but for keeping it simple, wanted to put this in front of eyes for feedback first.  

## Screen captures of before/after

### Before:
<img width="1009" alt="screen shot 2017-08-12 at 2 51 11 pm" src="https://user-images.githubusercontent.com/2396774/29243654-3d99ca2e-7f72-11e7-9225-2ac7669c5fa1.png">

### After:
<img width="1010" alt="screen shot 2017-08-12 at 2 50 33 pm" src="https://user-images.githubusercontent.com/2396774/29243655-3fc1281a-7f72-11e7-8dc9-4db2192a56c5.png">

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 5 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
- [X] General responsiveness

## Miscellaneous thoughts
- I provided some other styling options in the issue #111 comments.  The solution in this PR follows the simple, first option, but if we want anything more fancy, then there are some other options given in the issue.  My thought being to utilize some space within the code block for the download raw link from a vertical spacing perspective as well as trying to make it more obvious that the "download raw" link is associated with the code block.

- Semantically speaking I wonder if we should change this to a `<button>` instead of an `<a>`.  However, it doesn't look like the parent theme has much in the way of styling for `<button>` so that may also be something to be evaluated if you prefer.  Pretty minor though...just another thought...
