### PR TITLE
Feature: Remove jekyll-admin from production build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - nvm install 7.10.0
   - npm install
   - npm run build:js
+  - awk '!/jekyll-admin/' Gemfile > temp && mv temp Gemfile
 script:
   - ./_tests/build
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_install:
   - nvm install 7.10.0
   - npm install
   - npm run build:js
-  - awk '!/jekyll-admin/' Gemfile > temp && mv temp Gemfile
+  # Remove Jekyll Admin from Travis builds.
+  - awk '!/jekyll-admin/' Gemfile > Gemfile.temp && mv Gemfile.temp Gemfile
 script:
   - ./_tests/build
 before_deploy:


### PR DESCRIPTION
Fixes #87 

The quickest and easiest fix that I can think of for removing the `jekyll-admin` gem from the production build is to dynamically change the `Gemfile` in the production build.  Really all this is doing though is maybe slightly reducing the build times though right?

Comparing a build on travis with the `jekyll-admin` gem and one without the `jekyll-admin` gem it did save about 30 seconds.  Not sure if this was a coincidence or if it was from removing the `jekyll-admin` gem.  

The solution can also be expanded upon by maybe making it into its own bash script and having some debug output or something...but again, this is my shot at doing a quick solution for the issue.