### PR TITLE
Feature: Changing code download link to tab style

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -43,8 +43,10 @@
 ```{{ lang_highlight }}
 {{ file.content -}}
 ```
+{:.code-block-tab}
+
 <div class="clearfix">
-  <a href="{{ link }}" download class="align-right btn--small">download raw</a>
+  <a href="{{ link }}" download class="btn--small code-tab">download raw</a>
 </div>
 
 {% endfor %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -122,3 +122,22 @@ figure {
   clear: both;
   height: 0;
 }
+
+// Code Block Dowload Links
+.code-tab {
+  border: 1px solid #f2f3f3;
+  border-top: 0;
+  border-radius: 0 0 4px 4px;
+  background-color: #fafafa;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.125);
+  margin-top: -11px;
+  z-index: 10;
+  position: relative;
+  padding: 0.5em 1em;
+  float: right;
+  margin-left: 1em;
+}
+
+.code-block-tab {
+  border-bottom-right-radius: 0;
+}


### PR DESCRIPTION
This PR fixes #111.

## Solution
The code updates included in this PR will change the file include's "download raw" link to a tab style instead of a raw link style.  In order to do this, a couple of css classes and styles needed to make this possible.

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 5 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
- [X] General responsiveness

## A few screen caps from different browsers/devices
### MacOS Chrome
<kbd>
<img width="1017" alt="screen shot 2017-08-13 at 1 12 33 pm" src="https://user-images.githubusercontent.com/2396774/29251768-21d3a38e-8029-11e7-8be6-9df88cddb803.png">
</kbd>

### MacOS Safari (shrunken width)
<kbd>
<img width="497" alt="screen shot 2017-08-13 at 1 13 51 pm" src="https://user-images.githubusercontent.com/2396774/29251778-56d4f5c4-8029-11e7-8b9f-d39258260ca9.png">
</kbd>

### IPhone 5 Safari
<kbd>
<img alt="IPhone 5 Safari" src="https://user-images.githubusercontent.com/2396774/29251865-37138e38-802b-11e7-8b5e-b0aa325f7c8a.PNG">
</kbd>

### Win10 Edge
<kbd>
<img alt="Edge" src="https://user-images.githubusercontent.com/2396774/29251878-611373f6-802b-11e7-8b29-4b8e20b8b133.png">
</kbd>


### Win10 IE11
<kbd>
<img alt="IE11" src="https://user-images.githubusercontent.com/2396774/29251871-487624d8-802b-11e7-87dd-025e132f8814.png">
</kbd>


