### PR TITLE
Ignoring Vimeo URLs in htmlproofer

### DIFF
--- a/_tests/build
+++ b/_tests/build
@@ -22,5 +22,5 @@ bundle exec htmlproofer ./_site \
   --only-4xx \
   --check-html \
   --allow-hash-href \
-  --url-ignore vimeo.com \
+  --url-ignore "/vimeo.com/" \
   "$htmlproofer_args_extra"

--- a/_tests/build
+++ b/_tests/build
@@ -15,10 +15,12 @@ if [ "$1" = "--quick" ]; then
 fi
 
 # Run HTMLProofer
+# Ignore vimeo URLs because they get 403 errors from Travis intermittently.
 BUNDLE_GEMFILE=Gemfile bundle exec jekyll build \
   --config _config.yml,_config_dev.yml
 bundle exec htmlproofer ./_site \
   --only-4xx \
   --check-html \
   --allow-hash-href \
+  --url-ignore vimeo.com \
   "$htmlproofer_args_extra"


### PR DESCRIPTION
We're seeing weird 403 errors when Travis tries to hit Vimeo URLs, so we're
excluding them from dead link checks.