### PR TITLE
Feature: Addition of jekyll-responsive-image plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ node_modules
 npm-debug.log*
 *.swp
 _*preview*
-
 assets/js/main.min.js
 assets/js/script-compiled.js
+images/resized/

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem 'jekyll-admin', group: :jekyll_plugins
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?
 gem 'html-proofer', '3.7.2'
 gem 'mdl', '0.4.0'
-
+gem 'jekyll-responsive-image', '1.2.0'

--- a/_config.yml
+++ b/_config.yml
@@ -182,11 +182,13 @@ gems:
 - jekyll-sitemap
 - jekyll-feed
 - jemoji
+- jekyll-responsive-image
 whitelist:
 - jekyll-paginate
 - jekyll-sitemap
 - jekyll-feed
 - jemoji
+- jekyll-responsive-image
 category_archive:
   type: liquid
   path: "/categories/"
@@ -197,3 +199,20 @@ compress_html:
   clippings: all
   ignore:
     envs: development
+# jekyll-responsive-image configurations
+responsive_image:
+  template: _includes/responsive-image.html
+  default_quality: 90
+  sizes:
+    - width: 320
+    - width: 480
+    - width: 768
+    - width: 1024
+  base_path: images
+  output_path_format: images/resized/%{dirname}/%{width}/%{basename}
+  save_to_source: false
+media_renditions:
+  article:
+    sizes:
+      - "(min-width: 64em) 83vw" 
+      - "100vw"

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -12,10 +12,10 @@
   @param {boolean} "img_link" - Optional, default is false. If img should have
     the image overlay functionality that the theme provides.
   @param {string} "fig_caption" - Optional. Caption to be used with figure tag.
-  @param {string} "media_rendition" - Optional.  The title for the array of 
-    media queries to include for the "sizes" attribute on image tag that is 
-    listed in the global _config file. Currently, the only possible value is: 
-    "article", however, other arrays of sizes could be added in the future.
+  @param {string} "media_rendition" - Optional.  The title for the array of
+    media queries to include for the "sizes" attribute on image tag that is
+    listed in the global _config file. If it's not included then defaults to
+    "article".
 
 -->
 {% endcomment %}
@@ -27,10 +27,18 @@
 {% assign img_basepath = site.responsive_image.base_path | append: "/" | append: post_slug %}
 {% assign img_path = img_basepath | append: "/" | append: "full-traffic-graph.png" %}
 
+{% comment %}
+<!-- default media_rendition to "article" if not included in parmaters -->
+{% endcomment %}
+{% assign media_rendition = "article" %}
+{% if include.media_rendition %}
+  {% assign media_rendition = include.media_rendition %}
+{% endif %}
+
 {% responsive_image_block %}
     path: {{ img_path }}
     alt: {{ include.alt }}
     img_link: {{ include.img_link }}
     fig_caption: {{ include.fig_caption }}
-    media_rendition: {{ include.media_rendition }}
+    media_rendition: {{ media_rendition }}
 {% endresponsive_image_block %}

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -25,7 +25,7 @@
 {% endcomment %}
 {% assign post_slug =  page.path | replace:'.html','' | replace: '.md','' | replace: '_posts/', '' %}
 {% assign img_basepath = site.responsive_image.base_path | append: "/" | append: post_slug %}
-{% assign img_path = img_basepath | append: "/" | append: "full-traffic-graph.png" %}
+{% assign img_path = img_basepath | append: "/" | append: include.file %}
 
 {% comment %}
 <!-- default media_rendition to "article" if not included in parmaters -->

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,0 +1,36 @@
+{% comment %}
+<!--
+  Image Include
+
+  This partial is used as a "prequel" include that is used with the responsive
+  image template.  This partial's main purpose is to dynamically create the
+  full path for the image to then pass that path as well as the other
+  parameters to the responsive image plugin and template.
+
+  @param {string} "file" - Required. filename of the image.
+  @param {string} "alt" - Required. Alt attribute for image tag.
+  @param {boolean} "img_link" - Optional, default is false. If img should have
+    the image overlay functionality that the theme provides.
+  @param {string} "fig_caption" - Optional. Caption to be used with figure tag.
+  @param {string} "media_rendition" - Optional.  The title for the array of 
+    media queries to include for the "sizes" attribute on image tag that is 
+    listed in the global _config file. Currently, the only possible value is: 
+    "article", however, other arrays of sizes could be added in the future.
+
+-->
+{% endcomment %}
+
+{% comment %}
+<!-- determine the full path of the image -->
+{% endcomment %}
+{% assign post_slug =  page.path | replace:'.html','' | replace: '.md','' | replace: '_posts/', '' %}
+{% assign img_basepath = site.responsive_image.base_path | append: "/" | append: post_slug %}
+{% assign img_path = img_basepath | append: "/" | append: "full-traffic-graph.png" %}
+
+{% responsive_image_block %}
+    path: {{ img_path }}
+    alt: {{ include.alt }}
+    img_link: {{ include.img_link }}
+    fig_caption: {{ include.fig_caption }}
+    media_rendition: {{ include.media_rendition }}
+{% endresponsive_image_block %}

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -1,0 +1,58 @@
+{% comment %}
+<!--
+  Responsive Image Include
+
+  This partial is used with the responsive image plugin.  In the _config file,
+  this template is used as the default for responsive images to configure a
+  srcset value for images to ensure the best option for an image is used for a
+  specific user's browser.
+
+  @param {string} "path" - Required. Path to image file relative to the root
+  @param {string} "alt" - Required. Alt tag for image
+  @param {boolean} "img_link" - Optional, default is false. If img should have
+    popover link
+  @param {boolean} "fig" - Optional, default is false. If image should be
+    inside a figure tag
+  @param {string} "fig_caption" - Optional. Caption to be used with figure tag
+  @param {string} "rendition" - Optional.  If image should have sizes options.
+
+-->
+{% endcomment %}
+
+{% comment %}
+<!-- determine all image options for srcset -->
+{% endcomment %}
+{% capture srcset %}
+    {% for i in resized %}
+        {{ site.url }}/{{ i.path }} {{ i.width }}w,
+    {% endfor %}
+     {{ site.url }}/{{ original.path }} {{ original.width }}w
+{% endcapture %}
+
+{% comment %}
+<!-- determine sizes configurations for image -->
+{% endcomment %}
+{% assign rendition= site.media_renditions.[media_rendition] %}
+{% if rendition != nil %}
+  {% assign sizes = rendition.sizes | join: ', ' %}
+{%endif%}
+
+{% if fig %}
+<figure>
+{% endif %}
+
+{% if img_link %}
+  <a href="{{ site.url }}/{{ original.path }}">
+    <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
+  </a>
+{% else %}
+  <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
+{% endif %}
+
+{% if fig_caption %}
+  <figcaption>{{ fig_caption }}</figcaption>
+{% endif %}
+
+{% if fig %}
+</figure>
+{% endif %}

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -7,14 +7,15 @@
   srcset value for images to ensure the best option for an image is used for a
   specific user's browser.
 
-  @param {string} "path" - Required. Path to image file relative to the root
-  @param {string} "alt" - Required. Alt tag for image
+  @param {string} "path" - Required. Path to image file relative to the root.
+  @param {string} "alt" - Required. Alt attribute for image tag.
   @param {boolean} "img_link" - Optional, default is false. If img should have
-    popover link
-  @param {boolean} "fig" - Optional, default is false. If image should be
-    inside a figure tag
-  @param {string} "fig_caption" - Optional. Caption to be used with figure tag
-  @param {string} "rendition" - Optional.  If image should have sizes options.
+    the image overlay functionality that the theme provides.
+  @param {string} "fig_caption" - Optional. Caption to be used with figure tag.
+  @param {string} "media_rendition" - Optional.  The title for the array of 
+    media queries to include for the "sizes" attribute on image tag that is 
+    listed in the global _config file. Currently, the only possible value is: 
+    "article", however, other arrays of sizes could be added in the future.
 
 -->
 {% endcomment %}
@@ -37,7 +38,7 @@
   {% assign sizes = rendition.sizes | join: ', ' %}
 {%endif%}
 
-{% if fig %}
+{% if fig_caption %}
 <figure>
 {% endif %}
 
@@ -53,6 +54,6 @@
   <figcaption>{{ fig_caption }}</figcaption>
 {% endif %}
 
-{% if fig %}
+{% if fig_caption %}
 </figure>
 {% endif %}

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -12,7 +12,7 @@
   @param {boolean} "img_link" - Optional, default is false. If img should have
     the image overlay functionality that the theme provides.
   @param {string} "fig_caption" - Optional. Caption to be used with figure tag.
-  @param {string} "media_rendition" - Optional.  The title for the array of 
+  @param {string} "media_rendition" - Required.  The title for the array of 
     media queries to include for the "sizes" attribute on image tag that is 
     listed in the global _config file. Currently, the only possible value is: 
     "article", however, other arrays of sizes could be added in the future.
@@ -33,7 +33,7 @@
 {% comment %}
 <!-- determine sizes configurations for image -->
 {% endcomment %}
-{% assign rendition= site.media_renditions.[media_rendition] %}
+{% assign rendition = site.media_renditions.[media_rendition] %}
 {% if rendition != nil %}
   {% assign sizes = rendition.sizes | join: ', ' %}
 {%endif%}

--- a/_posts/2017-07-25-editor.md
+++ b/_posts/2017-07-25-editor.md
@@ -21,14 +21,7 @@ The size of my audience changed a bit in May 2017. The sharp-eyed reader may be 
 
 {% assign fig_caption = "Number of unique readers visiting [mtlynch.io](https://mtlynch.io) per week" | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% responsive_image_block %}
-    path: images/2017-07-25-editor/full-traffic-graph.png
-    alt: "Blog traffic graphs"
-    img_link: true
-    fig: true
-    fig_caption: {{ fig_caption }}
-    media_rendition: "article"
-{% endresponsive_image_block %}
+{% include image.html file="full-traffic-graph.png" alt="Blog traffic graphs" img_link=true fig_caption=fig_caption media_rendition="article" %}
 
 As you notice from the chart above, my numbers went from "too insignificant to appear in a graph" for most of the first year of the blog's existence to over 9,000 readers per week starting last May. From that point on, when I published a new post, the blog received up to 40,000 visitors per week.
 

--- a/_posts/2017-07-25-editor.md
+++ b/_posts/2017-07-25-editor.md
@@ -21,7 +21,7 @@ The size of my audience changed a bit in May 2017. The sharp-eyed reader may be 
 
 {% assign fig_caption = "Number of unique readers visiting [mtlynch.io](https://mtlynch.io) per week" | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% include image.html file="full-traffic-graph.png" alt="Blog traffic graphs" img_link=true fig_caption=fig_caption media_rendition="article" %}
+{% include image.html file="full-traffic-graph.png" alt="Blog traffic graphs" img_link=true fig_caption=fig_caption %}
 
 As you notice from the chart above, my numbers went from "too insignificant to appear in a graph" for most of the first year of the blog's existence to over 9,000 readers per week starting last May. From that point on, when I published a new post, the blog received up to 40,000 visitors per week.
 

--- a/_posts/2017-07-25-editor.md
+++ b/_posts/2017-07-25-editor.md
@@ -19,18 +19,16 @@ I started this blog in May of last year. I don't mean to brag, but by last April
 
 The size of my audience changed a bit in May 2017. The sharp-eyed reader may be able to spot the subtle shift in my traffic graph:
 
-{% capture fig_img %}
-[![Blog traffic graphs](/images/2017-07-25-editor/full-traffic-graph-sm.png){: .align-center}](/images/2017-07-25-editor/full-traffic-graph.png)
-{% endcapture %}
+{% assign fig_caption = "Number of unique readers visiting [mtlynch.io](https://mtlynch.io) per week" | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% capture fig_caption %}
-Number of unique readers visiting [mtlynch.io](https://mtlynch.io) per week
-{% endcapture %}
-
-<figure>
-  {{ fig_img | markdownify | remove: "<p>" | remove: "</p>" }}
-  <figcaption>{{ fig_caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
-</figure>
+{% responsive_image_block %}
+    path: images/2017-07-25-editor/full-traffic-graph.png
+    alt: "Blog traffic graphs"
+    img_link: true
+    fig: true
+    fig_caption: {{ fig_caption }}
+    media_rendition: "article"
+{% endresponsive_image_block %}
 
 As you notice from the chart above, my numbers went from "too insignificant to appear in a graph" for most of the first year of the blog's existence to over 9,000 readers per week starting last May. From that point on, when I published a new post, the blog received up to 40,000 visitors per week.
 

--- a/_tests/build
+++ b/_tests/build
@@ -22,5 +22,5 @@ bundle exec htmlproofer ./_site \
   --only-4xx \
   --check-html \
   --allow-hash-href \
-  --url-ignore "/vimeo.com/" \
+  --url-ignore "/vimeo.com/,/amzn.to/2ohoJ3O/" \
   "$htmlproofer_args_extra"


### PR DESCRIPTION
Fixes #116.

## Solution
This update adds the jekyll-responsive-image plugin into the site which provides the `srset` image capability for responsive images to attempt to have the browser decide which image is best for a user's browser.

- [X] The plugin's configurations are stored in the `responsive_image` key in the `_config` file.
- [X] The plugin generates different image files based on the `sizes` key in the plugin's configurations.  I added sizes based on common break points: 320, 480, 768, 1024.  If there are specific image sizes desired, they can be set there.
- [X] I added a `media_renditions` key that can be used for the `sizes` attribute in `<img>` tags.  I based these on the CSS for `<article>` tags as the images are all within that container.  We can certainly tweak that as necessary too.
- [X] The plugin generates the different image files in an `images/resized` directory and then copies to `_site` on site generation.  I added the `images/resized` directory to .gitignore as I don't think we want these under source control?  However, adding them could speed up/cache those for builds.  The more images and sizes there are the longer builds will take, so something we may want to keep an eye on as more images are added to the plugin.
- [X] Once an image is placed in a `responsive_image` tag or `responsive_image_block` then it will generate the different image sizes.
- [X] I added one image to the plugin for an example in the `_posts/2017-07-25-editor.md` post.  If you don't want this example, I can remove. 
- [X] I configured the responsive image plugin template in `_includes/responsive-image.html` file.  I attempted to make this template as flexible with as many options as possible given the site's images.  For example, you can have an image in a `<figure>` tag, with a popover link, without a popover link, plain image tag, custom classes, etc.  If you think any of these options are unnecessary, we can modify.
- [X] Included a "prequel" type of include that will allow you to simply write `path: foo.png` within a post.  However, instead of directly calling the responsive image tags within a post, you will have to call the "prequel" include.  See below or in the `_posts/2017-7-25-editor.md` for an example:
## Example of calling the "prequel" image template in post:
```
{% include image.html file="foo.png" alt="foo alt" img_link=true fig_caption="foo fig caption" media_rendition="article" %}
```

## Additional notes
- [ ] I tested the template with a couple images that have the whitespace issues and this solution fixes the whitespace issues along with loading different size images based on browser/device.  I started to test this with other images as well that weren't full width and having the whitespace issues, such as those images that are aligned-left or aligned-right and the solution doesn't work for those since srcset bumps the image to full width.  So, if the intent is to use this for those images too, then we need more work on the template/solution.
- [ ] The plugin really is just re-scaling the images from what it looks like, so for the mobile images, you will probably notice that it looks very similar to the original image, just quite smaller.  An example before/after screen cap is below for your information:

### Before plugin:
<kbd>
<img width="378" alt="screen shot 2017-08-20 at 9 57 41 pm" src="https://user-images.githubusercontent.com/2396774/29500939-aef2baec-85f2-11e7-98c0-39d6fb009a3e.png">
</kbd>

### After plugin:
<kbd>
<img width="379" alt="screen shot 2017-08-20 at 9 57 59 pm" src="https://user-images.githubusercontent.com/2396774/29500944-b20cb8a4-85f2-11e7-99bc-2d71886d4717.png">
</kbd>
 