### PR TITLE
Feature: Migrating responsive images in /editor post

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -19,7 +19,10 @@
   @param {string} "max_width" - Optional.  Overrides the media_rendition
     parameter.  This will set a max width for the image by setting the sizes
     attribute equal to the max_width value.
-  @param {string} "class" - Optional.  The CSS class attribute for the image
+  @param {string} "class" - Optional.  The CSS class attribute for the image or
+    figure.  If a figure tag is to be used, then the class will apply to the
+    figure tag.  If a figure tag is not being used, then the class will apply
+    to the image tag.
 -->
 {% endcomment %}
 

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -19,7 +19,10 @@
   @param {string} "max_width" - Optional.  Overrides the media_rendition
     parameter.  This will set a max width for the image by setting the sizes
     attribute equal to the max_width value.
-  @param {string} "class" - Optional.  The CSS class attribute for the image
+  @param {string} "class" - Optional.  The CSS class attribute for the image or
+    figure.  If a figure tag is to be used, then the class will apply to the
+    figure tag.  If a figure tag is not being used, then the class will apply
+    to the image tag.
 -->
 {% endcomment %}
 
@@ -46,7 +49,8 @@
 {% endif %}
 
 {% if fig_caption %}
-<figure>
+<figure class="{{ class }}">
+  {% assign class = "" %}
 {% endif %}
 
 {% if img_link %}

--- a/_posts/2017-07-25-editor.md
+++ b/_posts/2017-07-25-editor.md
@@ -35,7 +35,7 @@ If I compare by month, the blog grew by more than 20x month over month, and by m
 
 # What changed?
 
-[![Job posting for editing position](/images/2017-07-25-editor/editing-job-post-sm.png){: .align-right}](/images/2017-07-25-editor/editing-job-post.png)
+{% include image.html file="editing-job-post.png" alt="Job posting for editing position" img_link=true max_width="398px" class="align-right" %}
 
 Just before I went to bed on May 13, 2017, I posted a job for a blog editor on Upwork, a site I use regularly for hiring freelancers. Not a permanent position, just a one-time gig to read through my already posted articles, identify weak patterns in my writing, and suggest improvements.
 
@@ -43,7 +43,7 @@ When I woke up the next morning, I had already received applications from 10 dif
 
 Some of the matches were... not so strong. The lowest bidder, at $8/hr, told me she was, "well-equipped with knowledge how to teach writing." Another freelancer mentioned in her cover letter that, "editing and writing are [her] forte's [sic]."
 
-[![Job posting for editing position](/images/2017-07-25-editor/samantha-profile-sm.png){: .align-left}](/images/2017-07-25-editor/samantha-profile.png)
+{% include image.html file="samantha-profile.png" alt="Job posting for editing position" img_link=true max_width="260px" class="align-left" %}
 
 The strongest applicant was an editor named [Samantha Mason](https://www.upwork.com/fl/samanthamason). At $55/hr, she was almost twice as expensive as the next highest bidder. But her response was the only one that showed that she had actually read any of my writing. In her cover letter, she pointed out that I had a habit of diluting my sentences with helper verbs. "As you **can see** in the graph below," instead of simply, "As you **see** in the graph below."
 
@@ -62,18 +62,9 @@ I felt that my writing was pretty good but definitely had room for improvement. 
 
 Beyond my blog, investing in my writing would pay dividends in many aspects of my life. Writing is a highly transferable skill, much like public speaking, time management, or knife juggling. Techniques I learned to better my blog writing would likely carry over into design documents I write at work or even emails I send to friends.
 
-{% capture fig_img %}
-![Colbert with eyebrow raised](/images/2017-07-25-editor/colbert-eyebrow-raise.jpg)
-{% endcapture %}
+{% assign fig_caption = "“Your *editor*, you say?”" | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% capture fig_caption %}
-"Your *editor*, you say?"
-{% endcapture %}
-
-<figure class="align-right">
-  {{ fig_img | markdownify | remove: "<p>" | remove: "</p>" }}
-  <figcaption>{{ fig_caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
-</figure>
+{% include image.html file="colbert-eyebrow-raise.jpg" alt="Colbert with eyebrow raised" max_width="230px" fig_caption=fig_caption class="align-right" %}
 
 My other reason for hiring an editor was the most important: to give my friends,  family, and co-workers a misleadingly grandiose perception of my blog. Before, when I told someone that  I wrote a new blog post about [using Selenium to test Ansible roles](/testing-ansible-selenium/), they nodded politely and changed the subject. But when I started saying things like, "I'm rewriting my new post because my editor thinks that the introduction is too weak," people became intrigued. "Your *editor*?"
 
@@ -103,33 +94,13 @@ I wrote the article on a Thursday night in a non-stop, four-hour writing session
 
 The next morning, I published the article, ["How I Stole Your Siacoin,"](/stole-siacoins/) and posted the link to [reddit](https://reddit.com) and [Hacker News](https://news.ycombinator.com/), two popular link-sharing sites. By the end of the day, it was the most upvoted story of all-time on two of reddit's subforums, [/r/siacoin](https://www.reddit.com/r/Siacoin/top/) and [/r/cryptocurrency](https://www.reddit.com/r/CryptoCurrency/top/) (though a few days later, I was shamefully bumped from the #1 spot on /r/CryptoCurrency by [a picture of a sign](https://www.reddit.com/r/CryptoCurrency/comments/6i5ibl/its_happening/)). It had also gained enough traction on Hacker News to make it to their front page, an enviable accomplishment for tech bloggers.
 
-{% capture fig_img %}
-[![Visitor stats for How I Stole Your Siacoin post](/images/2017-07-25-editor/stole-siacoin-stats-sm.png)](/images/2017-07-25-editor/stole-siacoin-stats.png)
-{% endcapture %}
+{% assign fig_caption = "Blog visitor statistics on the day that [“How I Stole Your Siacoin”](/stole-siacoins/) was published." | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% capture fig_caption %}
-Blog visitor statistics on the day that ["How I Stole Your Siacoin"](/stole-siacoins/) was published.
-{% endcapture %}
-
-<figure>
-  {{ fig_img | markdownify | remove: "<p>" | remove: "</p>" }}
-  <figcaption>{{ fig_caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
-</figure>
+{% include image.html file="stole-siacoin-stats.png" alt="Visitor stats for How I Stole Your Siacoin post" img_link=true fig_caption=fig_caption %}
 
 I also noticed something interesting about the comments on the article. Many of them specifically praised the *style* of my writing:
 
-{% capture fig_img %}
-![Reddit comments](/images/2017-07-25-editor/reddit-comments.png){: .align-center}
-{% endcapture %}
-
-{% capture fig_caption %}
-Positive comments on the writing style of "How I Stole Your Siacoin." Creating this collage does not count as narcissism because I'm doing it for a blog post.
-{% endcapture %}
-
-<figure>
-  {{ fig_img | markdownify | remove: "<p>" | remove: "</p>" }}
-  <figcaption>{{ fig_caption | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
-</figure>
+{% include image.html file="reddit-comments.png" alt="Reddit comments" fig_caption="Positive comments on the writing style of “How I Stole Your Siacoin.” Creating this collage does not count as narcissism because I'm doing it for a blog post." %}
 
 I browse reddit frequently, and I don't recall seeing many users compliment submissions on their writing — though it should be noted that I don't recognize praise unless it's directed at me. The feedback seemed like such clear validation of my decision to hire an editor that I almost had to wonder if Samantha was surreptitiously posting these comments herself. *[**Editor's note**: There is no evidence to support this allegation.]*
 


### PR DESCRIPTION
This PR migrates the images in the /editor post over to using the jekyll-responsive-plugin implemented in #126.

In order to complete the image migration for the /editor post, there was one image that was in a figure tag and aligned to the right.  Previously, the `responsive-image` template did not take this scenario into account.  This scenario has been resolved in this PR by using the same `class` parameter and applying the following business rules within the template:
- If the image is configured to use a `<figure>` tag, then the class will apply to that tag only.  
- If the image is configured to use an `<image>` tag, then the class will apply to that tag as was previously implemented.