### PR TITLE
Feature: Migrating responsive images in /prosperbot

### DIFF
--- a/_posts/2016-11-26-prosperbot.md
+++ b/_posts/2016-11-26-prosperbot.md
@@ -34,7 +34,7 @@ To invest in peer to peer loans with Prosper, investors can use Prosper's web si
 
 I chose the API route and developed ProsperBot, a lending bot that continuously searches for new loans on Prosper and invests in them when they meet certain criteria. It also includes a web dashboard, which shows ProsperBot's current status and my Prosper account activity over time:
 
-[<img alt="ProsperBot screenshot" src="{{ base_path }}/images/2016-11-26-prosperbot/prosperbot-frontend.png" width="700" style="border:1px solid grey; display: block; margin-left: auto; margin-right: auto;" />]({{ base_path }}/images/2016-11-26-prosperbot/prosperbot-frontend.png)
+{% include image.html file="prosperbot-frontend.png" alt="ProsperBot screenshot" img_link="true" max_width="700px" class="align-center img-border" %}
 
 As you can see in the graph, my account has been steadily increasing in value since April, as ProsperBot receives repayments on loans and reinvests the cash in new loans. My total account value begins to decline in October, as I have begun withdrawing money from my Prosper account.
 


### PR DESCRIPTION
This PR migrates the images in the /prosperbot post over to using the jekyll-responsive-plugin implemented in #126.

This post contained 2 images, however, 1 image was an external image hosted on google drive so only the first image was migrated over to using the responsive plugin which easily fit into our existing model for image migration.

Straight forward migration, nothing special to note.