### PR TITLE
Feature: CSS fix for long captions on left & right aligned figure tags

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -95,6 +95,7 @@ figure {
     &-left {
       flex-direction: column;
       margin: 0 1em 0 0;
+      display: table;
 
       a {
         z-index: 1;
@@ -111,6 +112,11 @@ figure {
       margin-right: 1em;
     }
   }
+}
+
+figcaption {
+  display: table-caption;
+  caption-side: bottom;
 }
 
 // More robust clearfix class than what is in theme


### PR DESCRIPTION
This PR fixes #85 

This update includes a CSS change that will ensure that the figure captions do not stretch past the width of a left or right aligned issue.  This should do the trick and does not adversely affect captions on figures that are NOT left or right aligned.

## Long caption example of left aligned figure after the fix:
<kbd>
<img width="1030" alt="screen shot 2017-09-13 at 5 56 03 pm" src="https://user-images.githubusercontent.com/2396774/30403035-d4674ec8-98ad-11e7-9f14-9fa5481d78dc.png">
</kbd>

## Long caption example of right aligned figure after the fix:
<kbd>
<img width="1040" alt="screen shot 2017-09-13 at 5 54 29 pm" src="https://user-images.githubusercontent.com/2396774/30403038-d847ad76-98ad-11e7-94d3-80b887922fbc.png">
</kbd>

## Rare use case issue
There is one possible scenario where I think this solution may produce an undesirable result, however, I don't think it is very likely to occur so didn't take it into account.   That scenario could come into play if the figure caption contains a really long word that is larger than the image.  In this case, the image will stretch large enough to a width to contain that really long word.  As you can see in the below screen capture the "aaaa..." word extends the entire figure and breaks the rest of the caption to that minimum width as well:
<kbd>
<img width="1028" alt="screen shot 2017-09-13 at 6 13 04 pm" src="https://user-images.githubusercontent.com/2396774/30403381-546ea11a-98af-11e7-8fcf-ed5cc4123f87.png">
</kbd>

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 5 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
- [X] General responsiveness