### PR TITLE
Switching solution to empty alt tags in archive layout

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -20,7 +20,7 @@
           {% else %}
             "{{ teaser | absolute_url }}"
           {% endif %}
-           alt="{{ title }}">
+           alt="">
       </div>
     {% endif %}
     <h2 class="archive__item-title" itemprop="headline">

--- a/_tests/build
+++ b/_tests/build
@@ -12,6 +12,8 @@ mdl _posts _pages --style _linter/markdown-linter-style.rb
 htmlproofer_args_extra=""
 if [ "$1" = "--quick" ]; then
   htmlproofer_args_extra="--disable-external"
+else
+  htmlproofer_args_extra="--check-external-hash"
 fi
 
 # Run HTMLProofer
@@ -21,6 +23,8 @@ BUNDLE_GEMFILE=Gemfile bundle exec jekyll build \
 bundle exec htmlproofer ./_site \
   --only-4xx \
   --check-html \
+  --check-opengraph \
   --allow-hash-href \
+  --empty-alt-ignore \
   --url-ignore "/vimeo.com/" \
   "$htmlproofer_args_extra"


### PR DESCRIPTION
Instead of putting in a redundant alt tag, we should just leave it empty but
fix HTML-Proofer to not flag it as problematic. Also adds a few more HTML-Proofer
checks.