### PR TITLE
Feature: New Sidebar Links & Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ defaults:
     share: true
     related: true
     sidebar:
-       nav: "custom_sidebar"
+       nav: "main"
 - scope:
     path: ''
     type: pages
@@ -34,7 +34,7 @@ defaults:
     layout: single
     author_profile: true
     sidebar:
-       nav: "custom_sidebar"
+       nav: "main"
 locale: en-US
 title_separator: "-"
 name: Michael Lynch

--- a/_config.yml
+++ b/_config.yml
@@ -25,12 +25,16 @@ defaults:
     comments: true
     share: true
     related: true
+    sidebar:
+       nav: "custom_sidebar"
 - scope:
     path: ''
     type: pages
   values:
     layout: single
     author_profile: true
+    sidebar:
+       nav: "custom_sidebar"
 locale: en-US
 title_separator: "-"
 name: Michael Lynch

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,14 +1,10 @@
 # main links links
 main:
-  - title: "Blog"
-    url: /
-
-custom_sidebar:
   - title: 
     children:
     - title: "Blog"
       url: /
-    - title: "About Me"
+    - title: "About"
       url: /about/
     - title: "Projects"
       url: /projects/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,3 +2,13 @@
 main:
   - title: "Blog"
     url: /
+
+custom_sidebar:
+  - title: 
+    children:
+    - title: "Blog"
+      url: /
+    - title: "About Me"
+      url: /about/
+    - title: "Projects"
+      url: /projects/

--- a/_includes/mailing_list_form.html
+++ b/_includes/mailing_list_form.html
@@ -10,6 +10,8 @@
 -->
 {% endcomment %}
 
+{% unless page.hide_signup %}
+
 <!-- Begin MailChimp Signup Form -->
 
 <div class="sbscrb_cont">
@@ -40,3 +42,5 @@
 </div>
 
 <!--End mc_embed_signup-->
+
+{% endunless %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,0 +1,21 @@
+<div class="masthead">
+  <div class="masthead__inner-wrap">
+    <div class="masthead__menu">
+      <nav id="site-nav" class="greedy-nav">
+        <a class="site-title" href="{{ '/' | absolute_url }}">{{ site.title }}</a>
+        <ul class="visible-links">
+          {% for link in site.data.navigation.main[0].children %}
+            {% if link.url contains 'http' %}
+              {% assign domain = '' %}
+            {% else %}
+              {% assign domain = site.url | append: site.baseurl %}
+            {% endif %}
+            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+          {% endfor %}
+        </ul>
+        <button><div class="navicon"></div></button>
+        <ul class="hidden-links hidden"></ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,0 +1,8 @@
+---
+title: About Me
+permalink: "/about/"
+layout: single
+excerpt: All about me
+---
+
+Michael Lynch is a blogger on the Internet.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,8 +1,9 @@
 ---
-title: About Me
+title: About
 permalink: "/about/"
 layout: single
 excerpt: All about me
+hide_signup: true
 ---
 
 Michael Lynch is a blogger on the Internet.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -3,6 +3,7 @@ title: Projects
 permalink: "/projects/"
 layout: single
 excerpt: My projects
+hide_signup: true
 ---
 
 [GreenPiThumb](/greenpithumb/)

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,10 @@
+---
+title: Projects
+permalink: "/projects/"
+layout: single
+excerpt: My projects
+---
+
+[GreenPiThumb](/greenpithumb/)
+
+[ProsperBot](/prosperbot/)

--- a/_sass/child-theme/_main.scss
+++ b/_sass/child-theme/_main.scss
@@ -18,4 +18,5 @@
 @import 'components/anchors';
 @import 'components/code-block';
 @import 'components/figures';
+@import 'components/sidebar';
 @import 'components/subscription';

--- a/_sass/child-theme/_main.scss
+++ b/_sass/child-theme/_main.scss
@@ -18,5 +18,5 @@
 @import 'components/anchors';
 @import 'components/code-block';
 @import 'components/figures';
-@import 'components/sidebar';
+@import 'components/navigation';
 @import 'components/subscription';

--- a/_sass/child-theme/components/_navigation.scss
+++ b/_sass/child-theme/components/_navigation.scss
@@ -1,0 +1,25 @@
+// Custom Navigation Component
+
+.masthead {
+	display: block;
+
+	@include breakpoint($large) {
+    display: none;
+  }
+}
+
+.sidebar nav {
+	display: none;
+
+	@include breakpoint($large) {
+		display: block;
+	}
+
+	a {
+		font-size: 18px;
+	}
+}
+
+.nav__sub-title {
+	margin: 0.5rem 0 1.5rem
+}

--- a/_sass/child-theme/components/_sidebar.scss
+++ b/_sass/child-theme/components/_sidebar.scss
@@ -1,0 +1,5 @@
+// Custom Sidebar Component
+
+.nav__sub-title {
+	margin: 0.5rem 0 1.5rem
+}

--- a/_sass/child-theme/components/_sidebar.scss
+++ b/_sass/child-theme/components/_sidebar.scss
@@ -1,5 +1,0 @@
-// Custom Sidebar Component
-
-.nav__sub-title {
-	margin: 0.5rem 0 1.5rem
-}


### PR DESCRIPTION
This PR adds a new sidebar navigation to the website that is very easy to update and maintain and breaks down well responsively.  As we are adding new navigational links, this PR also stubs out the new pages for "About" and "Projects".

## How the current implementation looks:
First, I wanted to display a few screenshots to illustrate how the new sidebar and associated pages look when built using the feature branch from this PR.

### 1. Blog index page with new sidebar links and active item bolded (desktop version).
Also notice, no more masthead on desktop as that is what we will use for responsive breakdown of the sidebar menu.
<kbd>
<img width="1408" alt="screen shot 2017-09-25 at 10 28 39 pm" src="https://user-images.githubusercontent.com/2396774/30839786-e6a7a1a8-a241-11e7-9063-c1c81d820755.png">
</kbd>

### 2. Blog index page (ipad size version).
<kbd>
<img width="832" alt="screen shot 2017-09-25 at 10 28 58 pm" src="https://user-images.githubusercontent.com/2396774/30839815-0eeb85f8-a242-11e7-9e67-62cf301734cd.png">
</kbd>

### 2. Blog index page (mobile version where the sidebar nav pops up top and responsively puts the items into a hamburger menu)
### Closed menu
![img_0529](https://user-images.githubusercontent.com/2396774/30840167-c7492370-a243-11e7-8e4c-e2d59b49b4f1.PNG)

    <br><br>

### Open menu

![img_0530](https://user-images.githubusercontent.com/2396774/30840170-cb10547e-a243-11e7-859b-52133e05eb94.PNG)

### 3. About page (w/no email subscription)
<kbd>
<img width="1315" alt="screen shot 2017-09-25 at 10 39 07 pm" src="https://user-images.githubusercontent.com/2396774/30839892-77322a18-a242-11e7-8fa5-93b62dc4ddfa.png">
</kbd>

### 4. Projects page (w/no email subscription)
<kbd>
<img width="1292" alt="screen shot 2017-09-25 at 10 39 14 pm" src="https://user-images.githubusercontent.com/2396774/30839896-7a58fc8a-a242-11e7-9039-79f84a0cfed3.png">
</kbd>

## Additional details on solution
- [X] The parent theme provides an out-of-the-box capability for sidebar links & a masthead menu.  Based on their documentation, this was done by associating the main menu items in `_data/navigation.yml` with the `sidebar:` frontmatter item in the config for the default setups for posts & pages.  So, that provides us the capability to have a sidebar on desktop versions and a mobile top nav on responsive versions of the site.
- [X] The parent theme uses a "priority plus" [methodology](https://mmistakes.github.io/minimal-mistakes/docs/navigation/) for hiding/showing necessary top nav links based on browser width.  If you don't like how it shows hides nav items based on width, we could customize the parent theme to remove the "priority plus" navigation.
- [X] In order to have the sidebar breakdown responsively into a mobile hamburger type menu, we did have to customize the `_includes/masthead.html` from the parent.  Just wanted to point this out for future theme upgrades.
- [X] Also addressed the sidebar font size, changing "About Me" to just "About", and adding a capability to hide the email signup form on individual pages by adding a `hide_signup: true` frontmatter key to pages that the signup form should be hidden.

## Testing
This has now been tested across the following browsers/devices:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 5 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
- [X] General responsiveness

This PR fixes #148.

