### PR TITLE
Feature: Fixing favicon & adding HTMLProofer check

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,13 @@
+<!-- start custom head snippets -->
+
+<!-- inserting favicon references -->
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/img/favicon/android-chrome-192x192.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/favicon/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/assets/img/svg/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="shortcut icon" href="/assets/img/favicon/favicon.ico">
+<meta name="theme-color" content="#ffffff">
+
+<!-- end custom head snippets -->

--- a/_tests/build
+++ b/_tests/build
@@ -22,6 +22,7 @@ BUNDLE_GEMFILE=Gemfile bundle exec jekyll build \
   --config _config.yml,_config_dev.yml
 bundle exec htmlproofer ./_site \
   --only-4xx \
+  --check-favicon \
   --check-html \
   --check-opengraph \
   --allow-hash-href \

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
+            <square150x150logo src="/assets/img/favicon/mstile-150x150.png"/>
             <TileColor>#00aba9</TileColor>
         </tile>
     </msapplication>

--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,11 @@
   "orientation": "any",
   "icons": [
     {
-      "src": "/favicon-16x16.png",
+      "src": "/assets/img/favicon/favicon-16x16.png",
       "sizes": "16x16",
       "type": "image/png"
     }, {
-      "src": "/favicon-32x32.png",
+      "src": "/assets/img/favicon/favicon-32x32.png",
       "sizes": "32x32",
       "type": "image/png"
     }


### PR DESCRIPTION
This PR fixes #153 .

Currently, it does not appear as though there is a favicon on the production site.  I don't see any references to it in the html and doing a check with a [favicon checker](https://realfavicongenerator.net/), they don't seem to be able to find them either.
<kbd>
![screencapture-realfavicongenerator-net-favicon_checker-1506049929506](https://user-images.githubusercontent.com/2396774/30727962-a7248d10-9f22-11e7-8ced-cc6e8022f0be.png)
</kbd>

The parent theme includes a `_includes/head/custom.html` file where it seems that is where custom favicon references should be placed.  I added the favicon references to that file.

Additionally, I fixed a few broken references in related files dealing with the favicon.

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 6 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF

Also tested:
- [X] Tested the HTMLProofer check locally
- [X] My locally built site, post updates with a favicon checker and results as follows:

![screencapture-realfavicongenerator-net-favicon_checker-1506049942420](https://user-images.githubusercontent.com/2396774/30728089-98ba095c-9f23-11e7-8b00-2d7d4d188a73.png)

