### PR TITLE
Bug: Fixing hash permalinks

### DIFF
--- a/assets/js/_anchors.js
+++ b/assets/js/_anchors.js
@@ -25,13 +25,15 @@
 })();
 
 // enables hashtag relocation on in-page anchor links
-$(window).bind('hashchange', function(event) {
-  $.smoothScroll({
-    // Replace '#/' with '#' to go to the correct target and after scrollin
-    scrollTarget: location.hash.replace(/^\#\/?/, '#'),
-    afterScroll: function() {
-      location.hash = location.hash.replace(/^\#\/?/, '#');
-    }
+$(window).bind('load', function(event) {
+  $(window).bind('hashchange', function(event) {
+    $.smoothScroll({
+      // Replace '#/' with '#' to go to the correct target and after scrollin
+      scrollTarget: location.hash.replace(/^\#\/?/, '#'),
+      afterScroll: function() {
+        location.hash = location.hash.replace(/^\#\/?/, '#');
+      }
+    });
   });
 });
 


### PR DESCRIPTION
This issue fixes #160 

This pull request contains a bug fix where permalinks with a hash anchor location in the URL is not going to the correct anchor location on the page.  This issue appears to only affect Chrome oddly enough and was able to replicate on both Win & Mac Chrome v61.x.  

## Troubleshooting Findings Background
The issue does seem to be slightly intermittent however too.  For example, links that don't work consistently for me in Chrome:
- https://mtlynch.io/sia-nextcloud/#nextcloud
- https://mtlynch.io/greenpithumb/#deployment

Links that do work consistently for me:
- https://mtlynch.io/windows-sia-mining/#install-gpu-library
- https://mtlynch.io/stole-siacoins/#opening-the-safe
- https://mtlynch.io/sia-via-docker/#checking-for-success

The difference that I notice between these pages, is the pages that DON'T work consistently seem to have external assets, like videos, external images, etc.  So, it seems to me this is a loading/relocation ordering issue in Chrome.  In other words, the permalink relocation seems to be happening before some of the assets have completed loading.

It does seem odd to me that Chrome is behaving so differently compared to the other browsers here.  So, I reset commits on my local branch all the way down to where the permalinks were initially added to the site and the behavior was still occurring.  So, I can eliminate any layout changes causing this behavior.  This was either poor testing on my end, or maybe something has recently changed with how Chrome is handling the hashchange bind event upon initial load since we implemented the permalinks...not sure.

## Solution
In order to prevent and ensure the proper page load and then hash change relocation of pages, my solution was to add another bind event for page load, before the hash change event in the custom js file.  I have tested this solution across the usual environments again and this looks to work on my end pretty well.  The only issue I see is now you may see a slight delay when the page loads and then the page goes to the anchor link.  It does seem to consistently go to the right anchor location though.

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 6 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
