### PR TITLE
Feature: CSS update for mobile floating figures

### DIFF
--- a/_sass/child-theme/components/_figures.scss
+++ b/_sass/child-theme/components/_figures.scss
@@ -1,18 +1,24 @@
 // Figure tag classes
 
-figure {
-  &.align {
-    &-right,
-    &-left {
-      flex-direction: column;
-      margin: 0 1em 0 0;
-      display: table;
+figure.align {
+  &-right,
+  &-left {
 
-      a {
-        z-index: 1;
-      }
+    flex-direction: column;
+    margin: 0 auto;
+    display: table;
+    float: none;
+
+    @include breakpoint($small) {
+      margin: 0 1em 0 0;
     }
 
+    a {
+      z-index: 1;
+    }
+  }
+
+  @include breakpoint($small) {
     &-right {
       float: right;
       margin-left: 1em;


### PR DESCRIPTION
This PR fixes #161.

This pull request contains CSS changes that will stop the floating of figures on mobile breakpoints to prevent ugly line breaks from occurring.

The reason that the ugly line breaks are occurring is that certain figures that "aligned left" or "aligned right" aren't big enough to demand 100% of the width so they allow a minimal amount of text alongside the image.  In cases pointed out in #161 that minimal width is reduced even more with the implementation of an unordered list element.

## Solution
I think the best solution here is to remove the "float" from figures on mobile breakpoints.  This is already done on plain images, but we had not implemented it yet for figures since we had not run into the ugly line break case to date for figures.

## Screen capture examples of before/after the fix

### Before the fix (new post)
<kbd>
<img width="385" alt="screen shot 2017-10-01 at 11 31 55 am" src="https://user-images.githubusercontent.com/2396774/31056219-2a5e83ae-a69c-11e7-9dc8-18aa3e5d5cdc.png">
</kbd>

### After the fix (new post)
<kbd>
<img width="559" alt="screen shot 2017-10-01 at 11 16 04 am" src="https://user-images.githubusercontent.com/2396774/31056224-3782fdf8-a69c-11e7-9e13-b7b24a418b16.png">
</kbd>

This fix does affect other figure tags that are left or right aligned however.  Some of those figures didn't have an issue with line breaks on mobile previously, but this solution will adjust the figures for all situations.  If this is NOT desired, then I think we would need to apply a special class for the scenario.

### Example of another floated mobile image before fix
<kbd>
<img width="588" alt="screen shot 2017-10-01 at 11 17 01 am" src="https://user-images.githubusercontent.com/2396774/31056242-7d9bbdf2-a69c-11e7-9c20-2a312e6ff090.png">
</kbd>

### Example of another floated mobile image after fix
<kbd>
<img width="545" alt="screen shot 2017-10-01 at 11 17 10 am" src="https://user-images.githubusercontent.com/2396774/31056244-820f9214-a69c-11e7-838f-dcf19b676d97.png">
</kbd>


