### PR TITLE
Feature: Centering images by default

### DIFF
--- a/_posts/2016-11-26-prosperbot.md
+++ b/_posts/2016-11-26-prosperbot.md
@@ -36,7 +36,7 @@ To invest in peer to peer loans with Prosper, investors can use Prosper's web si
 
 I chose the API route and developed ProsperBot, a lending bot that continuously searches for new loans on Prosper and invests in them when they meet certain criteria. It also includes a web dashboard, which shows ProsperBot's current status and my Prosper account activity over time:
 
-{% include image.html file="prosperbot-frontend.png" alt="ProsperBot screenshot" img_link="true" max_width="700px" class="align-center img-border" %}
+{% include image.html file="prosperbot-frontend.png" alt="ProsperBot screenshot" img_link="true" max_width="700px" class="img-border" %}
 
 As you can see in the graph, my account has been steadily increasing in value since April, as ProsperBot receives repayments on loans and reinvests the cash in new loans. My total account value begins to decline in October, as I have begun withdrawing money from my Prosper account.
 

--- a/_posts/2017-01-11-taskrabbit-cooking.md
+++ b/_posts/2017-01-11-taskrabbit-cooking.md
@@ -138,7 +138,7 @@ The tables below show my full costs for each cooking session. I bought all the i
 | Labor (2 hours) | $55.90 |
 | **Total**                                          | **$109.89** |
 
-{% include image.html file="cooking-costs.png" alt="ProsperBot screenshot" img_link="true" max_width="750px" class="align-center img-border" %}
+{% include image.html file="cooking-costs.png" alt="ProsperBot screenshot" img_link="true" max_width="750px" class="img-border" %}
 
 ## How does this compare to restaurant delivery?
 

--- a/_posts/2017-08-06-sia-nextcloud.md
+++ b/_posts/2017-08-06-sia-nextcloud.md
@@ -30,7 +30,7 @@ If you prefer video tutorials, I recommend you download the files in the ["Creat
 
 This guide is aimed at **intermediate users**. If you don't have any experience with Docker containers or virtual machines or you're not comfortable using the command line, it will be difficult for you to follow this guide.
 
-{% include image.html file="bad-time.png" alt="You're gonna have a bad time" max_width="597px" class="align-center" %}
+{% include image.html file="bad-time.png" alt="You're gonna have a bad time" max_width="597px" %}
 
 I used Windows 10 in the video demo, but this tutorial is completely system-agnostic. The steps I provide will work on any 64-bit operating system that supports Docker, which includes Windows, Mac OS X, Linux, and even some [network storage devices](/sia-via-docker).
 

--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -3,3 +3,13 @@
 h1, h2, h3, h4, h5, h6 {
   position: relative;
 }
+
+figure {
+  display: table;
+  margin: 2em auto;
+}
+
+img {
+  display: block;
+  margin: 0 auto;
+}

--- a/_sass/child-theme/components/_figures.scss
+++ b/_sass/child-theme/components/_figures.scss
@@ -1,12 +1,15 @@
 // Figure tag classes
 
+figure.half, figure.third {
+  display: flex;
+}
+
 figure.align {
   &-right,
   &-left {
 
     flex-direction: column;
     margin: 0 auto;
-    display: table;
     float: none;
 
     @include breakpoint($small) {

--- a/_tests/build
+++ b/_tests/build
@@ -17,7 +17,8 @@ else
 fi
 
 # Run HTMLProofer
-# Ignore vimeo URLs because they get 403 errors from Travis intermittently.
+# Ignore vimeo and upwork URLs because they get 403 errors from Travis
+# intermittently.
 BUNDLE_GEMFILE=Gemfile bundle exec jekyll build \
   --config _config.yml,_config_dev.yml
 bundle exec htmlproofer ./_site \
@@ -27,5 +28,5 @@ bundle exec htmlproofer ./_site \
   --check-opengraph \
   --allow-hash-href \
   --empty-alt-ignore \
-  --url-ignore "/vimeo.com/" \
+  --url-ignore "/vimeo.com/,/upwork.com/" \
   "$htmlproofer_args_extra"


### PR DESCRIPTION
This issue fixes #167 

This update changes the default alignment for images and figures to centered.  Currently, the default is to left-align images, but this PR will change that to centering images and figures by default.

## Solution
In order to accomplish this, I added an override class in the child theme to center images and figures in the `base.scss` file.  In doing so, one feature that did break were images that were supposed to display side-by-side.  In order to fix that display issue, I did need to set the `display: flex` back for images that are supposed to align side-by-side with the `half` or `third` classes.  An example of this display is on the https://mtlynch.io/greenpithumb/ page.

Additionally, in order to keep things clean, I also removed all `align-center` classes within 3 posts.  `align-center` won't harm anything, but it also won't do anything since that is the default now.

## New HTMLProofer Ignore
Finally, I was receiving 403 errors on the upwork.com links with HTMLProofer when running the tests locally and in Travis.  I'm not sure if something has changed in their config or cert, but also added a new ignore for these URLs in the build script as well.

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 6 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF
