### PR TITLE
Bug: Fixing right and left aligned figure captions

### DIFF
--- a/_sass/child-theme/components/_figures.scss
+++ b/_sass/child-theme/components/_figures.scss
@@ -10,6 +10,7 @@ figure.align {
 
     flex-direction: column;
     margin: 0 auto;
+    display: table;
     float: none;
 
     @include breakpoint($small) {


### PR DESCRIPTION
This PR fixes #170.

This PR includes a CSS fix that was introduced during PR #168.  I removed a CSS property that I shouldn't have thinking it was not needed and must have tested the left/right align use-case before removing that property.  This PR reverts removing that CSS property and have confirmed this fixes the captions under right and left aligned images.

I also performed regression testing to ensure this would not affect the rest of what was included in #168 so centering images by default still works as it should.