### PR TITLE
Bug: Incorrect font size in list item preceding an image

### DIFF
--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -66,11 +66,11 @@
 {% endif %}
 
 {% if img_url %}
-  <a href="{{ img_url }}">
-    <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
-  </a>
-{% else %}
+<a href="{{ img_url }}">
   <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
+</a>
+{% else %}
+<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
 {% endif %}
 
 {% if fig_caption %}


### PR DESCRIPTION
This PR fixes #181.

## The Problem
It appears as though in situations where the image include is placed after a list in the markdown, the include is placing the html into the markdown with indentation, thereby causing the markdown renderer to think that the image is actually part of the list item, when in fact it should be located outside of the list in this case.  See the html snippet below of how the image is rendering inside of the list item:
```html
<ul>
  <li>The tone of discussion is becoming tense or hostile.</li>
  <li>Your notes per review round are not trending downward.</li>
  <li>
    <p>You’re getting pushback on an unusually high number of your notes.</p>

    <p><a href="http://localhost:4000/images/2017-10-31-human-code-reviews-2/pilots.png" class="image-popup">
     <img src="/images/2017-10-31-human-code-reviews-2/pilots.png" alt="Tension during code review" srcset="http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/320/pilots.png 320w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/480/pilots.png 480w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/768/pilots.png 768w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/1024/pilots.png 1024w,http://localhost:4000/images/2017-10-31-human-code-reviews-2/pilots.png 2000w" sizes="850px" class="">
    </a></p>
  </li>
</ul>
```

## Solution
We can handle this in 1 of 2 ways.  
1.  We can alter the CSS so that the font size also targets the above scenario in a similar fashion as list items without `<p>` tags.
2.  Or we can remove the indentation in the html file.

I chose option 2 for the solution for now as I think this is probably the more _proper_ way to handle this bug.  The negative is maybe slightly less clean looking code in the include since we are removing spacing in the code for readability.  But again, I think this probably renders the markdown/content in a more desirable fashion.  We may even want to think about refactoring the include to maybe try and put all of the html into a string and then run a `strip` whitespace function on it, but I think that is a larger effort and not sure how beneficial it would be from a cost perspective.
With removing the whitespace in the responsive-image include the content now renders as shown below and resolves the font size issue:
```html
<ul>
  <li>The tone of discussion is becoming tense or hostile.</li>
  <li>Your notes per review round are not trending downward.</li>
  <li>You’re getting pushback on an unusually high number of your notes.</li>
</ul>

<p><a href="http://localhost:4000/images/2017-10-31-human-code-reviews-2/pilots.png" class="image-popup">
  <img src="/images/2017-10-31-human-code-reviews-2/pilots.png" alt="Tension during code review" srcset="http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/320/pilots.png 320w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/480/pilots.png 480w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/768/pilots.png 768w,http://localhost:4000/images/resized/2017-10-31-human-code-reviews-2/1024/pilots.png 1024w,http://localhost:4000/images/2017-10-31-human-code-reviews-2/pilots.png 2000w" sizes="850px" class="">
</a></p>
```