### PR TITLE
Bug: Removing link underlines in content

### DIFF
--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -13,3 +13,7 @@ img {
   display: block;
   margin: 0 auto;
 }
+
+a {
+  text-decoration: none;
+}


### PR DESCRIPTION
This PR fixes #182.

This update adds a css rule to the child theme SASS files for all `<a>` elements to remove the underline text decoration when the link is not being hovered.  I assume the desire would be to keep the underline in the hover state however?

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 6 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF

Also tested to make sure that links in the header/footer/nav areas also remained unchanged as it seems as though those links kept the no-underline style.  The bug only seemed to affect links contained in content sections.  

**Please NOTE** this fix also removes the underlines on non "posts" pages as well, for example the projects page links no longer have underlines when in the non-hover state:

### Before
<kbd>
<img width="1025" alt="screen shot 2017-11-03 at 9 16 23 pm" src="https://user-images.githubusercontent.com/2396774/32400869-482d804c-c0dc-11e7-8f48-824185a4f23e.png">

</kbd>

### After
<kbd>
<img width="1025" alt="screen shot 2017-11-03 at 9 14 14 pm" src="https://user-images.githubusercontent.com/2396774/32400863-2f003ad8-c0dc-11e7-9bc5-25a47af6610c.png">
</kbd>
