### PR TITLE
Feature: Discussion social media post buttons

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -13,6 +13,7 @@ en: &DEFAULT_EN
   less_than                  : "less than"
   minute_read                : "minute read"
   share_on_label             : "Share on"
+  discuss_on_label           : "Discuss on"
   meta_label                 :
   tags_label                 : "Tags:"
   categories_label           : "Categories:"

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -1,0 +1,24 @@
+<section class="page__share">
+  {% if site.data.ui-text[site.locale].share_on_label %}
+    <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
+  {% endif %}
+
+  <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i><span> Twitter</span></a>
+
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i><span> Facebook</span></a>
+
+  <a href="https://plus.google.com/share?url={{ page.url | absolute_url | url_encode }}" class="btn btn--google-plus" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Google Plus"><i class="fa fa-fw fa-google-plus" aria-hidden="true"></i><span> Google+</span></a>
+
+  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
+
+  {% if page.discuss_urls %}
+    <h4 class="page__share-title">{{ site.data.ui-text[site.locale].discuss_on_label | default: "Discuss on" }}</h4>
+
+    {% for discuss in page.discuss_urls %}
+    
+      <a href="{{ discuss[1] }}" class="btn btn-discuss btn--{{ discuss[0] | downcase }}" title="{{ site.data.ui-text[site.locale].discuss_on_label | default: 'Discuss on' }} {{ discuss[0] | capitalize }}"><i class="fa fa-fw fa-{{ discuss[0] | replace: '_', '-' | downcase }}" aria-hidden="true"></i><span> {{ discuss[0] | replace: '_', ' ' }}</span></a>
+    
+    {% endfor %}
+  {% endif %}
+
+</section>

--- a/_sass/child-theme/_main.scss
+++ b/_sass/child-theme/_main.scss
@@ -17,6 +17,7 @@
 
 // Including individual components
 @import 'components/anchors';
+@import 'components/buttons';
 @import 'components/code-block';
 @import 'components/figures';
 @import 'components/navigation';

--- a/_sass/child-theme/components/_buttons.scss
+++ b/_sass/child-theme/components/_buttons.scss
@@ -1,0 +1,32 @@
+// Buttons Component
+
+.btn-discuss {
+  background-color: #3b5998;
+  color: #fff;
+  text-transform: capitalize;
+
+  &:hover {
+    color: #fff;
+  }
+
+  &:visited {
+    color: #fff;
+  }
+}
+
+.btn--reddit {
+  background-color: #ff5700;
+  text-transform: lowercase;
+
+  &:hover {
+    background-color: #e54e00;
+  }
+}
+
+.btn--hacker_news {
+  background-color: #ff6500;
+
+  &:hover {
+    background-color: #e55b00;
+  }
+}


### PR DESCRIPTION
This PR fixes #185.

This update adds social media buttons to a "Discuss on" section on any blog posts that include a `discuss_urls:` yaml frontmatter key.  That frontmatter key should include an array of social media website names and the corresponding URL that the article is being shared and discussed.

The following scenarios are possible for the `discuss_urls` key:

|Description of scenario|Resulting output|
|:---------------------- |:--------------- |
|no `discuss_urls` frontmatter key in a post|results in no "Discuss on" section (just like current production)|
|`discuss_urls` frontmatter key exists, but no array items (just blank)|results in no "Discuss on" section|
|`discuss_urls` frontmatter key contains n array items|results in a "Discuss on" section with n buttons|

The array items that make up the value for the `discuss_urls:` frontmatter key should be in the following format:
```yaml
discuss_urls:
  <social_media_website_name_1>: <full url of the sharing url 1>
  <social_media_website_name_2>: <full url of the sharing url 2>
  <social_media_website_name_3>: <full url of the sharing url 3>
```

This update supports Hacker News, reddit, in addition to any of the parent theme defined social media websites.  However, if there is a social media site that isn't covered, this solution will still work just fine.  The exception is there may not be an icon in front of the text on the button and it would use the default button colors.  If additional customization was needed for additional social media websites for this functionality, that would need to be handled with additional css and icons.  **Bottom line though this is a flexible solution to be able to add more "discussion urls" if ever desired.**

In order to get this solution to work, I did have to pull down the parent theme's `_includes/social-share.html` file and customize that.  As discussed, I will try to make this solution fit into the parent theme so hopefully that will not be an issue for future theme updates.  If we can't get this into the parent theme, then we may want to think about creating a separate include for the discussion urls section, but I think it could complicate some css to get it to look right...should be doable though.

## Screenshots of the new functionality on the 3 major breakpoints:

### Desktop
<kbd>
<img width="1384" alt="screen shot 2017-11-11 at 4 37 09 pm" src="https://user-images.githubusercontent.com/2396774/32693798-b34f7c7c-c6fe-11e7-8d7c-63b58720b32c.png">
</kbd>

### Tablet
<kbd>
<img width="839" alt="screen shot 2017-11-11 at 4 37 49 pm" src="https://user-images.githubusercontent.com/2396774/32693802-bb73ed48-c6fe-11e7-941c-57f8071a16d6.png">
</kbd>

### Mobile
<kbd>
<img  alt="mobiel" src="https://user-images.githubusercontent.com/2396774/32693812-e2845008-c6fe-11e7-83d3-f4c0dc86f554.jpg">
</kbd>

## Testing 
Tested this solution in:
- [X] Mac Chrome, FF, Safari
- [X] Iphone 6 Chrome, Safari
- [X] Win10 Edge, IE 11, Chrome, FF





