### PR TITLE
Bug: Ipad display for blog posts fix

### DIFF
--- a/_sass/child-theme/layouts/_page.scss
+++ b/_sass/child-theme/layouts/_page.scss
@@ -2,7 +2,7 @@
 
 .page {
   @include breakpoint($large) {
-  width: span(10 of 12);
+  width: span(9.5 of 12);
   padding-left: gutter(0.5 of 12);
   padding-right: gutter(2 of 12);
 }


### PR DESCRIPTION
This PR fixes #192 .

This code change contains a simple CSS change that will slightly modify the width of an article so that blog posts on landscape views of tablets (specifically ipads) will not drop down below the left sidebar on initial loading of the article at the top of the page.

Probably the best way to explain this is to show a before the fix (current production) and after the fix screenshot:

## Before the fix contained in this PR:
<kbd>
<img src="https://user-images.githubusercontent.com/2396774/32693908-6fd7d662-c701-11e7-8849-3be908891eb7.PNG">
</kbd> 

## With the fix contained in this PR:
<kbd>
<img src="https://user-images.githubusercontent.com/2396774/32693913-88fb3e9a-c701-11e7-882c-70fcaab8342e.PNG">
</kbd> 