### PR TITLE
Bug: Fixing figure and image tag spacing to be equivalent

### DIFF
--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -6,7 +6,8 @@ h1, h2, h3, h4, h5, h6 {
 
 figure {
   display: table;
-  margin: 2em auto;
+  margin: 0em auto 1.3em;
+  font-size: 0.9em;
 }
 
 img {

--- a/_sass/child-theme/components/_figures.scss
+++ b/_sass/child-theme/components/_figures.scss
@@ -38,6 +38,7 @@ figure.align {
 figcaption {
   display: table-caption;
   caption-side: bottom;
+  margin-bottom: 0;
 }
 
 .img-border {


### PR DESCRIPTION
This PR fixes #199.

As pointed out in #199 there was more top/bottom margin spacing on `<figure>` tags as opposed to `<image>` tags.  In order to make the spacing (margins) equivalent, this required a few minor CSS rules to be applied to `<figure>` and `<figcaption>` tags.  The rules in this PR make the spacing for the tags exactly the same now.

As you can see in the screen caps below, the margins are now the same for above/below `<image>` tags as well as `<figure>` tags:

### Before bugfix
As you can see the current site has 44px computed margins above and below `figure` tags.
<kbd>
<img width="1440" alt="screen shot 2017-12-04 at 9 29 24 pm" src="https://user-images.githubusercontent.com/2396774/33587372-d0135366-d93b-11e7-95d6-3fdffb7ef597.png">
</kbd>

And on `<image>` tags, currently the margins are based on the parent `<p>` tag and has a computed margin of 25.74px above and below.
<kbd>
<img width="1440" alt="screen shot 2017-12-04 at 9 42 54 pm" src="https://user-images.githubusercontent.com/2396774/33587445-29ce93a2-d93c-11e7-8d3c-b7b24140994b.png">
</kbd>

### After bugfix
With the code contained in this bugfix, you can see the computed margins for `<figure>` tags are now 0 on top and 25.74px on the bottom.  So, the bottom margins are now exactly the same.
<kbd>
<img width="1440" alt="screen shot 2017-12-04 at 9 28 36 pm" src="https://user-images.githubusercontent.com/2396774/33587390-f597e0f2-d93b-11e7-833c-31a83adc5323.png">
</kbd>

Finally, you can see that above the figures are going to be a `<p>` tag which has a computed bottom margin of 25.74px already, so now the top margins match exactly just like the current `<image>` tags.
<kbd>
<img width="1440" alt="screen shot 2017-12-04 at 9 28 41 pm" src="https://user-images.githubusercontent.com/2396774/33587412-07c9ac56-d93c-11e7-9456-78913ad0676f.png">
</kbd>






