### PR TITLE
Bug: Firefox image max widths fix

### DIFF
--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -67,10 +67,10 @@
 
 {% if img_url %}
 <a href="{{ img_url }}">
-  <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
+  <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
 </a>
 {% else %}
-<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}">
+<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
 {% endif %}
 
 {% if fig_caption %}


### PR DESCRIPTION
This PR fixes #205.

Interestingly enough, it appears doing some testing on FF, Chrome, Safari, and IE Edge that this issue only affects Firefox.  It appears as though Firefox is the lone browser that is allowing CSS to override the `sizes` attribute of image tags.

So, my solution will force inline CSS to override the default CSS if a max-width is being set.  This appears to set the width properly in Firefox and doesn't impact other browser's rendering of the image either.  That's the best thing I can think to offer here since Firefox is rendering differently...

Here is the image displaying with the inline CSS fix on the `cartoonists` branch:

<img width="1433" alt="screen shot 2017-12-30 at 7 56 18 pm" src="https://user-images.githubusercontent.com/2396774/34458433-b8ba2392-eda0-11e7-996a-4f9e95570e0a.png">

