### PR TITLE
Feature: Upgrading Minimal Mistakes theme to 4.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 3.5.1'
-gem 'minimal-mistakes-jekyll', '4.6.0'
+gem 'jekyll', '~> 3.7.0'
+gem 'minimal-mistakes-jekyll', '4.9.0'
 gem 'jekyll-admin', group: :jekyll_plugins
 
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?

--- a/_config.yml
+++ b/_config.yml
@@ -104,6 +104,7 @@ author:
   avatar: images/bio-photo.jpg
   bio: By day, a simple software engineer. By night, also a software engineer.
   location: New York, NY
+  home: /
   email: 
   uri: 
   bitbucket: 

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -34,7 +34,7 @@
       <p class="page__date">{{ post.date | date: "%B %-d, %Y" }}</p>
     {% endif %}
     {% if post.read_time %}
-      <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
+      <p class="page__meta"><i class="far fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
     {% endif %}
     {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
   </article>

--- a/_includes/author-profile-custom-links.html
+++ b/_includes/author-profile-custom-links.html
@@ -1,5 +1,5 @@
 <li>
   <a href="https://www.reddit.com/user/mtlynch/submitted">
-    <i class="fa fa-fw fa-reddit" aria-hidden="true"></i> reddit
+    <i class="fab fa-fw fa-reddit" aria-hidden="true"></i> reddit
   </a>
 </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,16 +8,16 @@
       <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
     {% endif %}
     {% if site.twitter.username %}
-      <li><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fa fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
+      <li><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
     {% endif %}
     {% if site.facebook.username %}
-      <li><a href="https://facebook.com/{{ site.facebook.username }}"><i class="fa fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
+      <li><a href="https://facebook.com/{{ site.facebook.username }}"><i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
     {% endif %}
     {% if site.author.github %}
-      <li><a href="http://github.com/{{ site.author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> GitHub</a></li>
+      <li><a href="http://github.com/{{ site.author.github }}"><i class="fab fa-fw fa-github" aria-hidden="true"></i> GitHub</a></li>
     {% endif %}
     {% if site.author.bitbucket %}
-      <li><a href="http://bitbucket.org/{{ site.author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
+      <li><a href="http://bitbucket.org/{{ site.author.bitbucket }}"><i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
     {% endif %}
     <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | absolute_url }}{% endif %}"><i class="fa fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
   </ul>

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -3,20 +3,20 @@
     <h4 class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</h4>
   {% endif %}
 
-  <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i><span> Twitter</span></a>
+  <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fab fa-fw fa-twitter" aria-hidden="true"></i><span> Twitter</span></a>
 
-  <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i><span> Facebook</span></a>
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fab fa-fw fa-facebook" aria-hidden="true"></i><span> Facebook</span></a>
 
-  <a href="https://plus.google.com/share?url={{ page.url | absolute_url | url_encode }}" class="btn btn--google-plus" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Google Plus"><i class="fa fa-fw fa-google-plus" aria-hidden="true"></i><span> Google+</span></a>
+  <a href="https://plus.google.com/share?url={{ page.url | absolute_url | url_encode }}" class="btn btn--google-plus" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Google Plus"><i class="fab fa-fw fa-google-plus" aria-hidden="true"></i><span> Google+</span></a>
 
-  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
+  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span> LinkedIn</span></a>
 
   {% if page.discuss_urls %}
     <h4 class="page__share-title">{{ site.data.ui-text[site.locale].discuss_on_label | default: "Discuss on" }}</h4>
 
     {% for discuss in page.discuss_urls %}
     
-      <a href="{{ discuss[1] }}" class="btn btn-discuss btn--{{ discuss[0] | downcase }}" title="{{ site.data.ui-text[site.locale].discuss_on_label | default: 'Discuss on' }} {{ discuss[0] | capitalize }}"><i class="fa fa-fw fa-{{ discuss[0] | replace: '_', '-' | downcase }}" aria-hidden="true"></i><span> {{ discuss[0] | replace: '_', ' ' }}</span></a>
+      <a href="{{ discuss[1] }}" class="btn btn-discuss btn--{{ discuss[0] | downcase }}" title="{{ site.data.ui-text[site.locale].discuss_on_label | default: 'Discuss on' }} {{ discuss[0] | capitalize }}"><i class="fab fa-fw fa-{{ discuss[0] | replace: '_', '-' | downcase }}" aria-hidden="true"></i><span> {{ discuss[0] | replace: '_', ' ' }}</span></a>
     
     {% endfor %}
   {% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -31,7 +31,7 @@ layout: default
             <p class="page__date">{{ page.date | date: "%B %-d, %Y" }}</p>
           {% endif %}
           {% if page.read_time %}
-            <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
+            <p class="page__meta"><i class="far fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
           {% endif %}
         </header>
       {% endunless %}
@@ -50,9 +50,9 @@ layout: default
         {% endif %}
         {% include page__taxonomy.html %}
         {% if page.last_modified_at %}
-          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%-d" }}">{{ page.last_modified_at | date: "%B %-d, %Y" }}</time></p>
+          <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%-d" }}">{{ page.last_modified_at | date: "%B %-d, %Y" }}</time></p>
         {% elsif page.date %}
-          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time></p>
+          <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time></p>
         {% endif %}
       </footer>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimal-mistakes",
-  "version": "4.6.0",
+  "version": "4.9.0",
   "description": "Minimal Mistakes Jekyll theme npm build scripts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes #211 and #176.

The updates included in this pull request will bump the parent theme (Minimal Mistakes) from version 4.6.0 to 4.9.0 which as stated in #211 includes the fixes for #176.

In order to update the parent theme the following items needed to be done:
- [X] updating the gem version in the `Gemfile` and `package.json`
- [X] bumping the jekyll version to the latest of `3.7.0` (the parent them's minimum jekyll version is `3.6.0` but figure might as well bump to latest...)
- [X] setting the author `home: \` key in `_config.yml` which will link the author name & avatar to the root of the website, per #176.
- [X] finally, the theme also bumped to the next major version of FontAwesome, so per guidance from the theme followed [these directions](https://fontawesome.com/how-to-use/upgrading-from-4) which basically means we needed to adjust the font awesome icon classes in several of the layouts/includes too.
- [X] performed light regression testing in each of the major current browsers and devices.