### PR TITLE
Feature: Migrating build process to docker container (Locale fixed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,5 @@
 sudo: false
-language: ruby
-rvm:
-  - 2.4.1
-env:
-  global:
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-before_install:
-  - nvm install 7.10.0
-  - npm install
-  - npm run build:js
-  # Remove Jekyll Admin from Travis builds.
-  - sed -i '/jekyll-admin/d' Gemfile
-script:
-  - ./_tests/build
+script: pushd _tests && ./docker_build && popd
 deploy:
   provider: firebase
   token:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services:
   - docker
 dist: trusty
-script: pushd _tests && ./docker_build && popd
+script: _tests/docker_build
 deploy:
   provider: firebase
   token:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: false
+sudo: required
+services:
+  - docker
+dist: trusty
 script: pushd _tests && ./docker_build && popd
 deploy:
   provider: firebase

--- a/_tests/Dockerfile
+++ b/_tests/Dockerfile
@@ -12,4 +12,9 @@ RUN \
 RUN \
   gem install bundler
 
+# Set default locale for the environment
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
 WORKDIR /app

--- a/_tests/Dockerfile
+++ b/_tests/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/node:8-stretch
+
+# Speed up installation of html-proofer.
+ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true
+
+# Install Ruby.
+RUN \
+  apt-get update && \
+  apt-get install -y ruby ruby-dev
+
+# Install bundler.
+RUN \
+  gem install bundler
+
+WORKDIR /app

--- a/_tests/docker_build
+++ b/_tests/docker_build
@@ -16,8 +16,8 @@ docker run --tty --detach --volume "${PWD}/..:/app" --name "$CONTAINER_NAME" "$I
 docker exec "$CONTAINER_NAME" npm install
 
 docker exec "$CONTAINER_NAME" npm run build:js
-# Remove Jekyll Admin from prod build.
 
+# Remove Jekyll Admin from prod build.
 docker exec "$CONTAINER_NAME" sed -i '/jekyll-admin/d' Gemfile
 
 docker exec "$CONTAINER_NAME" bundle install

--- a/_tests/docker_build
+++ b/_tests/docker_build
@@ -9,9 +9,9 @@ IMAGE_VERSION=$(git rev-parse HEAD)
 IMAGE_NAME="mtlynch-io:${IMAGE_VERSION}"
 CONTAINER_NAME="mtlynch-io-container"
 
-docker build -t "$IMAGE_NAME" .
+docker build -t "$IMAGE_NAME" _tests/
 
-docker run --tty --detach --volume "${PWD}/..:/app" --name "$CONTAINER_NAME" "$IMAGE_NAME"
+docker run --tty --detach --volume "${PWD}:/app" --name "$CONTAINER_NAME" "$IMAGE_NAME"
 
 docker exec "$CONTAINER_NAME" npm install
 

--- a/_tests/docker_build
+++ b/_tests/docker_build
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Exit on first failing command.
+set -e
+# Echo commands to console.
+set -x
+
+IMAGE_VERSION=$(git rev-parse HEAD)
+IMAGE_NAME="mtlynch-io:${IMAGE_VERSION}"
+CONTAINER_NAME="mtlynch-io-container"
+
+docker build -t "$IMAGE_NAME" .
+
+docker run --tty --detach --volume "${PWD}/..:/app" --name "$CONTAINER_NAME" "$IMAGE_NAME"
+
+docker exec "$CONTAINER_NAME" npm install
+
+docker exec "$CONTAINER_NAME" npm run build:js
+# Remove Jekyll Admin from prod build.
+
+docker exec "$CONTAINER_NAME" sed -i '/jekyll-admin/d' Gemfile
+
+docker exec "$CONTAINER_NAME" bundle install
+
+docker exec "$CONTAINER_NAME" _tests/build
+


### PR DESCRIPTION
This PR builds off of #224 and fixes #221.

As described in #221 the goal of this feature is to move the current build and test process to a Docker container. @mtlynch recreated this process completely in #224 however the node:8-stretch doesn't set the locale in its image that I could find so I added locale settings in c09bbd4 to the `Dockerfile` and that resolves the Unicode errors experienced.
