### PR TITLE
Bug: Remove "figure hack" & fix CSS for mobile images

### DIFF
--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -60,8 +60,10 @@
   {% assign img_url = site.url | append: "/" | append: original.path %}
 {% endif %}
 
+{% if fig_caption %}
 <figure class="{{ class }}">
-{% assign class = "" %}
+  {% assign class = "" %}
+{% endif %}
 
 {% if img_url %}
 <a href="{{ img_url }}">
@@ -75,4 +77,6 @@
   <figcaption>{{ fig_caption }}</figcaption>
 {% endif %}
 
+{% if fig_caption %}
 </figure>
+{% endif %}

--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -13,6 +13,7 @@ figure {
 img {
   display: block;
   margin: 0 auto;
+  width: 100%;
 }
 
 a {


### PR DESCRIPTION
This PR fixes #237.

This update reverses the quick fix put in place in #236 in the `_includes/responsive-image.html` template as well as adds an additional css property:value for base image tags.  

The root of the issue was on mobile browsers, flat image tags (without figure tags surrounding them) were using the "inline" max-size attribute and not shrinking down to container widths.  With this update the image will expand/collapse according to its container until it hits the max-width it can handle.

