### PR TITLE
Switching Travis language to Python to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 services:
   - docker
 dist: trusty
+language: python
+python:
+  - "2.7"
 script: _tests/docker_build
 deploy:
   provider: firebase


### PR DESCRIPTION
The actual language doesn't matter because we're doing everything in a Docker container, so we should just use whatever is fastest.