### PR TITLE
Revert "Switching to pre-built jekyll Docker image (#248)"

### DIFF
--- a/_tests/docker_build
+++ b/_tests/docker_build
@@ -5,8 +5,11 @@ set -e
 # Echo commands to console.
 set -x
 
-IMAGE_NAME="mtlynch/jekyll"
+IMAGE_VERSION=$(git rev-parse HEAD)
+IMAGE_NAME="mtlynch-io:${IMAGE_VERSION}"
 CONTAINER_NAME="mtlynch-io-container"
+
+docker build -t "$IMAGE_NAME" _tests/
 
 docker run --tty --detach --volume "${PWD}:/app" --name "$CONTAINER_NAME" "$IMAGE_NAME"
 


### PR DESCRIPTION
This reverts commit 24bb05cc10508e555baa404945d6f63ef6fd3588.