### PR TITLE
Feature: Updating Jekyll to 3.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 3.7.0'
+gem 'jekyll', '~> 3.8.2'
 gem 'minimal-mistakes-jekyll', '4.9.0'
 gem 'jekyll-admin', group: :jekyll_plugins
 


### PR DESCRIPTION
This PR fixes #256 .

This is a simple update to ensure the site is built with Jekyll 3.8.2 locally and for production. Version 3.8.2 is the latest stable jekyll release as of this PR.

From my perspective, I updated the version in the site's Gemfile and then performed some regression testing to ensure no noticeable odd behavior, which none was observed.  This is the first step in taking advantage of a few new Jekyll features recently released.