### PR TITLE
Feature: Enabling strict liquid filters, strict liquid parsing, & strict front matter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -175,6 +175,10 @@ kramdown:
   toc_levels: 1..6
   smart_quotes: lsquo,rsquo,ldquo,rdquo
   enable_coderay: false
+liquid:
+  error_mode:        strict
+  strict_filters:    true
+strict_front_matter: true
 sass:
   sass_dir: _sass
   style: compressed

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -45,7 +45,7 @@
 {% if max_width %}
   {% assign sizes = max_width %}
 {% else %}
-  {% assign rendition = site.media_renditions.[media_rendition] %}
+  {% assign rendition = site.media_renditions[media_rendition] %}
   {% if rendition %}
     {% assign sizes = rendition.sizes | join: ', ' %}
   {% endif %}


### PR DESCRIPTION
This PR fixes #257.

Per #257, this update enables enables strict liquid filters so builds will fail if an invalid/undefined liquid filter is used.  As all of the filters we have in the parent and child theme's templates are valid, no additional work was required aside from the configuration change.

In addition to enabling strict liquid filters, I also found 2 other configurations I think would also be helpful and seemed logical to make them as part of this PR as well.  They can obviously be taken out easily though if they are not desired.  Those 2 additional configurations were:

1. **Liquid `error_mode`** - In researching the [new liquid options](https://jekyllrb.com/docs/configuration/#liquid-options), I also found that we could enable a "strict" mode for error handling, which I wasn't aware of before.  But this will make it so if there are any liquid errors at all, the build will fail.  And after setting this, I also found a minor liquid syntax bug (extra '.') in the `_includes\responsive-image.html` template.  This wasn't affecting image display, but could in the future I suppose, so I can see how having this may help down the round, so opting to set this to `strict` as part of this PR.

2. **Strict front matter** - I thought this might be another useful feature to enforce valid yml frontmatter syntax for posts.  Currently, invalid yml syntax seems to just throw a warning, but having `strict_front_matter` enabled, will throw the error AND stop the build as well.  So, again, I think this has some benefits too and I think it would be helpful to enable it.  **NOTE: If this messes with any writing/editing flows though, we can certainly remove...**

