### PR TITLE
Feature: Adding post/subdirectory checking to file embed

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -40,6 +40,14 @@
   {% endif %}
   {% assign link = site.baseurl | append: '/files/' | append: file_path %}
 
+  {% comment %}
+  <!-- determine file's subdirectory to compare to post subdirectory -->
+  {% endcomment %}
+  {% assign subdir_array = file.path | split: '/' %}
+  {% assign subdir = subdir_array[1] %}
+
+  {% if subdir == page.slug %}
+
 ```{{ lang_highlight }}
 {{ file.content -}}
 ```
@@ -48,5 +56,7 @@
 <div class="clearfix">
   <a href="{{ link }}" download class="btn--small code-tab">download raw</a>
 </div>
+
+  {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
This PR fixes #283 .

**Please note this update is submitted against the "master" branch as opposed to the "duplicate-include-poc" branch**.

# Problem:
The current file embed feature finds the necessary file to be embedded based on a comparison of the `title=xxx` include parameter when including a file in a post to the `title: xxx` frontmatter key in the file embed itself.  As was discovered in #283 if there are 2 file embeds with the same `title:` frontmatter key, then the embed feature displays both files.

# Solution:
In order to remedy the duplication, we must have another identifier to more specifically inform jekyll which file to include in the above scenario.  Since all the file includes are utilizing a directory structure with the same exact name as the post, we can use some liquid logic to also compare the subdirectory of the embedded file to the actual post's slug (or filename without the extension & preceding date).

The solution in the commit adds the logic so it will parse out the subdirectory from the file embed's full path and explicitly compare the subdirectory to the post's slug.  We could simplify the code by adding a simple logic check like `{% if file.path contains page.slug %}` and I think that would be perfectly adequate.  However, I went with a more verbose logic to make sure there wouldn't be any exceptions with subdirectory/post names.  Probably splitting hairs, but I think the more verbose code is safer here.

# Testing:
I testing this solution against the "duplicate-include-poc" branch that was having issues and the problem was resolved by correctly identifying the proper file embed.  I also did regression testing, in my feature branch off of master, against all other file embeds and yml embeds that the site currently has implemented and those embeds still function properly as well.
