### PR TITLE
Feature: Adding exception liquid filter & warning for duplicate

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -66,13 +66,22 @@
 
 {% endfor %}
 
-{% comment %}
-<!-- if there has been more than 1 file with the same title found, then 
-     raise an error as this is likely not intentional -->
-{% endcomment %}
 {% if file_count > 1 %}
+  {% comment %}
+  <!-- if there has been more than 1 file with the same title found, then 
+       raise an error as this is likely not intentional -->
+  {% endcomment %}
   {{ "Multiple file includes with the same title, " 
     | append: include.title 
     | append: ", have been found." 
+    | raise_exception: "error" }}
+{% elsif file_count == 0 %}
+  {% comment %}
+  <!-- if there has been NO files found in the subdirectory that match the
+       title, then raise an error -->
+  {% endcomment %}
+  {{ "Zero file includes matched the title, " 
+    | append: include.title 
+    | append: ".  Please check the file include's title and directory again." 
     | raise_exception: "error" }}
 {% endif %}

--- a/_includes/files.html
+++ b/_includes/files.html
@@ -29,6 +29,11 @@
 	{% assign lang_highlight = include.language %}
 {% endif %}
 
+{% comment %}
+<!-- initialize file count -->
+{% endcomment %}
+{% assign file_count = 0 %}
+
 {% for file in files %}
 
   {% comment %}
@@ -56,7 +61,18 @@
 <div class="clearfix">
   <a href="{{ link }}" download class="btn--small code-tab">download raw</a>
 </div>
-
+    {% assign file_count = file_count | plus: 1 %}
   {% endif %}
 
 {% endfor %}
+
+{% comment %}
+<!-- if there has been more than 1 file with the same title found, then 
+     raise a warning as this is likely not intentional -->
+{% endcomment %}
+{% if file_count > 1 %}
+  {{ "Multiple file includes with the same title, " 
+    | append: include.title 
+    | append: ", have been found." 
+    | raise_exception }}
+{% endif %}

--- a/_includes/files.html
+++ b/_includes/files.html
@@ -68,11 +68,11 @@
 
 {% comment %}
 <!-- if there has been more than 1 file with the same title found, then 
-     raise a warning as this is likely not intentional -->
+     raise an error as this is likely not intentional -->
 {% endcomment %}
 {% if file_count > 1 %}
   {{ "Multiple file includes with the same title, " 
     | append: include.title 
     | append: ", have been found." 
-    | raise_exception }}
+    | raise_exception: "error" }}
 {% endif %}

--- a/_plugins/lib/jekyll-exception-filter.rb
+++ b/_plugins/lib/jekyll-exception-filter.rb
@@ -1,0 +1,30 @@
+module Jekyll
+  module ExceptionFilter
+
+
+    # A generic Jekyll Filter that will raise an excpetion from liquid.
+    #
+    # @param {string} msg - A string representing the actual verbage to display
+    #        in the console.
+    # @param {string} type = A string representing the type of error to raise
+    #        in the console.  The default is "warn" to display a warning
+    #        message that would NOT stop the build, just alert the user.
+    #        Alternatively, "err" can be used for critical errors shown in red
+    #        that halts the build.
+    def raise_exception(msg, type = "warn")
+    	
+    	bad_file = @context.registers[:page]['path']
+    	err_msg = "In #{bad_file}: #{msg}"
+
+    	if type == "err"
+      	raise err_msg
+      else
+     		warn err_msg.yellow 
+      end
+
+    end
+
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ExceptionFilter)

--- a/_plugins/lib/jekyll-exception-filter.rb
+++ b/_plugins/lib/jekyll-exception-filter.rb
@@ -17,10 +17,10 @@ module Jekyll
     	bad_file = @context.registers[:page]['path']
     	err_msg = "In #{bad_file}: #{msg}"
 
-    	if type == "error"
-      	raise err_msg
-      elsif type == "warning"
-     		warn err_msg.yellow 
+    	if type == "warning"
+      	warn err_msg.yellow 
+      else
+     		raise err_msg
       end
 
     end

--- a/_plugins/lib/jekyll-exception-filter.rb
+++ b/_plugins/lib/jekyll-exception-filter.rb
@@ -7,18 +7,19 @@ module Jekyll
     # @param {string} msg - A string representing the actual verbage to display
     #        in the console.
     # @param {string} type = A string representing the type of error to raise
-    #        in the console.  The default is "warn" to display a warning
-    #        message that would NOT stop the build, just alert the user.
-    #        Alternatively, "err" can be used for critical errors shown in red
-    #        that halts the build.
-    def raise_exception(msg, type = "warn")
+    #        in the console.  This can either be:
+    #          - "warning" - Displays a warning message that does NOT stop the
+    #                        build, simply used to alert the user.
+    #          - "error"   - Used for critical erros and halts the build on
+    #                        first occurence fo the problem.
+    def raise_exception(msg, type)
     	
     	bad_file = @context.registers[:page]['path']
     	err_msg = "In #{bad_file}: #{msg}"
 
-    	if type == "err"
+    	if type == "error"
       	raise err_msg
-      else
+      elsif type == "warning"
      		warn err_msg.yellow 
       end
 


### PR DESCRIPTION
Fixes #296 

This feature adds the ability to be able to raise build errors/warnings directly from logic that is encapsulated in Jekyll templates by way of a [liquid filter type of plugin](https://jekyllrb.com/docs/plugins/#liquid-filters).  This type of plugin registers additional capabilities and logic that aren't included with the base liquid templating language, extending its capabilities.

In addition to adding the generic exception filter, this PR also contains updated logic in the file include so that if the situation occurs where the same title is used on multiple file includes within the same directory, then a **warning** message will be displayed in the console as shown in the example screenshot below:

<img width="825" alt="screen shot 2018-08-09 at 10 50 16 pm" src="https://user-images.githubusercontent.com/2396774/43936811-5e7732c6-9c28-11e8-872a-f2eda9fc0a6a.png">

The exception message verbage is obviously configurable so that it can be applied to other situations that should warn the user.  In addition, the "type" of error is also configurable between a warning or an error.  The difference is a warning will **NOT** stop the site from building, but an **error** will stop the build upon the first occurrence of the error.

### Other notes:
- we can change the color of warning messages if you'd like, I just chose yellow as it seemed logical.  The critical error messages display in red.
- we can also change the verbage of the file include with duplicate titles if there is something that would make more sense for you.  I took a stab at what made sense to me...
