### PR TITLE
Feature: Configuring htmlproofer for localhost

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,7 +7,7 @@ sidebar:
 permalink: "/about/"
 excerpt: About the author
 header:
-  teaser: images/_pages/about/author-photo.jpg
+  teaser: images/about/author-photo.jpg
 hide_signup: true
 ---
 

--- a/_tests/build
+++ b/_tests/build
@@ -31,6 +31,7 @@ bundle exec htmlproofer ./_site \
   --check-opengraph \
   --allow-hash-href \
   --empty-alt-ignore \
+  --url-swap "http\://localhost\:4000/:/" \
   --url-ignore "/vimeo.com/,/upwork.com/" \
   "$htmlproofer_args_extra"
 


### PR DESCRIPTION
Fixes #307.

First of all apologies for breaking the images in #305 !  HTMLProofer caught one issue in the content, so I thought it would catch any others as well.  As you discovered, that wasn't the case.  I should've done a local search on my own to double check.

At any rate, looks like this actually illustrated a flaw in our configuration of HTMLProofer.  HTMLProofer actually does check Opengraph URLs already, however, the issue is the theme uses absolute URLs in many places (probably required for Opengraph references...) and when we build the site for HTMLProofer to run its checks, it puts `http://localhost:4000` in front of all the absolute URL references.  

Due to the absolute URL references, HTMLProofer thinks it is an "external" link and tries to find `http://localhost:4000`.  It obviously can't, but since HTMLProofer is also configured with the `--only-4xx` flag, it doesn't report an error.

I also tried changing the main nav "blog" link to "/doesn't-exist" and ran the test with the current HTMLProofer configuration and it didn't error out, because similar to the Opengraph URLs, the main navigation URLs are also absolute URLs in the theme's template.

So, I think our optimal solution here is to use HTMLProofer's `--url-swap` flag to find any instances of "http://localhost:4000/" (which is what the `_config-dev.yml`'s url is set too minus the trailing slash) and change it to "/" for purposes of the HTMLProofer tests.

With this updated configuration, we actually will get a more robust test coverage with absolute URL references and it actually found one more issue in the about page's teaser as well.