### PR TITLE
Styling: Reducing bottom margin on figures

### DIFF
--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -8,6 +8,10 @@ figure {
   display: table;
   margin: 0em auto 1.3em;
   font-size: 0.9em;
+
+  img {
+    margin-bottom: 0em;
+  }
 }
 
 img {


### PR DESCRIPTION
Fixes #309.

This styling update removes the bottom margin that is added to images within `<figure>` tags which are used for captions.

You can see the below/after screenshots below:
### Before
<img width="723" alt="screen shot 2018-08-15 at 8 22 46 pm" src="https://user-images.githubusercontent.com/2396774/44180204-2ab25100-a0c9-11e8-91f8-035d810416cd.png">

### After
<img width="714" alt="screen shot 2018-08-15 at 8 23 21 pm" src="https://user-images.githubusercontent.com/2396774/44180216-33a32280-a0c9-11e8-8fb7-65762a793e90.png">
