### PR TITLE
BUG: Jekyll/Jekyll Admin race condition remediation

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -35,13 +35,10 @@
 {% assign file_count = 0 %}
 
 {% comment %}
-<!-- create an empty array to store UNIQUE file paths that match the correct
-  file path and title.  Unfortunately due to Jekyll Admin bug, this array of 
-  UNIQUE files is part of the workaround to ensure no false positives are
-  thrown for duplicate title error catching. -->
+<!-- initialize an empty string to store unique file paths that match the
+  correct file path and title. -->
 {% endcomment %}
-{% assign found_file_array = " " | split: ',' %}
-{% assign found_file_array = found_file_array | shift %}
+{% assign found_files = "" %}
 
 {% for file in files %}
 
@@ -63,13 +60,11 @@
   {% if subdir == page.slug %}
 
     {% comment %}
-    <!-- check to see if any files have been stored in the UNIQUE array of
-      files.  If not, then push the file_path into the array.  This is only
-      needed as part of a workaround to ensure the same file is counted twice
-      for duplicate title error trapping. -->
+    <!-- check to see if any files have been stored (or found) yet.  If string
+      is empty, set it to the current file's path. -->
     {% endcomment %}
-    {% if found_file_array.size == 0 %}
-      {% assign found_file_array = found_file_array | push: file_path %}
+    {% if found_files == "" %}
+      {% assign found_files = file_path %}
 
 ```{{ lang_highlight }}
 {{ file.content -}}
@@ -83,18 +78,21 @@
     {% else %}
     
       {% comment %}
-      <!-- iterate through found_file_array and check if the same file_path
-        already exists.  If the same file_path already exists, do nothing.
-        Otherwise, add the new file_path to the array so that the duplicate
-        file title error check will trigger below.  This is only needed as part
-        of a workaround to ensure the same file is counted twice for duplicate
-        title error trapping. -->
+      <!-- split the found files string into an array and check each entry to
+        see if it is a duplicate of current file.  If it is not a duplicate,
+        then append to the found_files string.  If it is a dupilcate (due to
+        Jekyll admin bug or a different reason) then ignore. -->
       {% endcomment %}
+      {% assign already_found = "" %}
+      {% assign found_file_array = found_files | split: ',' %}
       {% for found_file in found_file_array %}
         {% if found_file != file_path %}
-          {% assign found_file_array = found_file_array | push: file_path %}
+          {% assign already_found = file_path %}
         {% endif %}
       {% endfor %}
+      {% if already_found != "" %}
+        {% assign found_files = found_files | append: "," | append: already_found %}
+      {% endif %}
 
     {% endif %}
   {% endif %}
@@ -107,7 +105,7 @@
   Any other value should be raised as an exception as that means duplicate
   titles were found for a file in the same directory. -->
 {% endcomment %}
-{% assign file_count = found_file_array | size %}
+{% assign file_count = found_files | split: ',' | size %}
 
 {% unless file_count == 1 %}
   {% if file_count == 0 %}


### PR DESCRIPTION
Fixes #310 

This PR includes a workaround for the problem pointed out in #310.  Unfortunately, attempts at finding the root cause have not been fruitful, however, since this issue is:
- only reproducable under certain conditions AND while using `Jekyll-admin` to alter content 
- and is not a problem when building the production site
I feel like this workaround should be sufficient to eliminate the bigger problems of this bug.

## What this workaround WILL do
This workaround will:
- [X] Ensure there are no false positives for duplicate file include titles by creating an array of file paths and checking to ensure the same file path is not "counted" as a duplicate file title
- [X] Provide the intended and original functionality for pro-actively finding duplicate and/or incorrect file include titles

## What this workaround DOESN'T do
This workaround doesn't:
- [ ] Address the `conflicting chdir during another chdir block` build warning.  This appears to be at the root of the issue, but again, only occurs when using `Jekyll-admin` for editing content.  So, I believe, the race condition is still present, but doesn't affect how the site is built either for production or when using `Jekll-admin`.

## Attempts at finding the root of the race condition
I have tried several different things to try and get to the root of the race condition unsuccessfully.  Here are things I have tried:
- Created a very basic Jekyll site with a "files" collection.  Could not reproduce the race condition behavior however thus far on the most basic of Jekyll sites.  It should be noted that build times are significantly faster with such a basic site however.  Based on further attempts, I believe the condition mostly presents itself when build times are over a couple of seconds, otherwise, very difficult to reproduce.
- After the basic site, I then started trying to add mtlynch.io functionality piece-by-piece, but couldn't reproduce until adding more and more posts or more and more functionality.  So, I don't think there is anything in our site's code that is causing this, I believe, this has more to do with build times, but it's very difficult to get any consistency with this.
- Built the site using the initial commit of mtlynch.io to see if there was something we introduced along that way that caused this, however, even with that build, I saw the `conflicting chdir during another chdir block` build warnings using `Jekyll-admin` so adding collections and functionality does not seem to have caused this.
- Tried updating Ruby versions, Jekyll, Jekyll-responsive-image, and other gems, but no effect on the condition.  Could be some other benefits that I will try to get a PR together for though.

## Additional Notes
- [X] **There was a broken link in the `2017-05-20-windows-sia-mining.md` post, so I added an ignore to the HTMLProofer parameters to get the build successful**
- [X] **Please note** this PR does change the "warning" liquid exceptions back to "error" exceptions

I can continue to try and identify what the root cause issue is with this, but this could be very time consuming and wanted to get the workaround in for now at least so intended functionality isn't limited.  My gut feeling is this has something to do with the Jekyll "watch" process interferring with the spawned Jekyll-admin sinatra servers also "watching" files/directories and both processes attempting to access the same files at the same time.  From what I've read it seems the `chdir` command isn't thread safe in Ruby so that is causing the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/mtlynch.io/316)
<!-- Reviewable:end -->
