### PR TITLE
Styling: Image bottom margin issue for aligned images

### DIFF
--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -10,7 +10,7 @@ figure {
   font-size: 0.9em;
 
   img {
-    margin-bottom: 0em;
+    margin-bottom: 0.1em;
   }
 }
 


### PR DESCRIPTION
Fixes #315 

This PR fixes a regression pointed out in #315.  It looks like this regression occurred when we implemented the bottom margin = 0 on #312.  Taking the margin down to 0 appears to have been a little too much and caused some overlapping issues with captions in very specific circumstances and in Chrome only from what I could tell.

Given the border is 1px wide, taking the margin to `0.1em` looks to fix the issue in Chrome and no regression in FF or Safari either.

Below is the fixed screenshot from the test branch:

<img width="1302" alt="screen shot 2018-09-02 at 12 32 59 pm" src="https://user-images.githubusercontent.com/2396774/44958353-1afa8100-aead-11e8-981e-aae5c1057c40.png">
