### PR TITLE
Styling: Adjusting lists next to floated images

### DIFF
--- a/_sass/child-theme/base/_base.scss
+++ b/_sass/child-theme/base/_base.scss
@@ -23,3 +23,7 @@ img {
 a {
   text-decoration: none;
 }
+
+ul, ol {
+  overflow: hidden;
+}


### PR DESCRIPTION
Fixes #323 

This PR fixes the spacing issue identified in #323 where lists next to floated images have the bullets not spaced nicely.  This solution adds a `overflow:hidden` rule to lists which forces a new block formatting context for the list's contents and thus positioning said block next to the floated image.

This fix is the most quick and dirty solution that I can think of that:
1) won't impact other lists in the site
2) minimizes the use of a special class that could hamper add additional complexity for entering lists in markdown
3) achieves the nicer spacing look that lists across the site currently use -- consistency

The only issues this might present are:
1) if the list next to the floated image is very long, the list won't "float" around the image, which may or may not be desired, but does defeat the purpose of "floated" images if the list doesn't "float" around it technically I suppose...
2) I think very old versions of IE this wouldn't work on... like IE6/7...  tested on Edge & IE11 and looks good though.

New spacing with new CSS rule applied:
<img width="1364" alt="screen shot 2018-09-14 at 9 29 31 pm" src="https://user-images.githubusercontent.com/2396774/45580989-5ca00a00-b865-11e8-8ba4-5fe55961f611.png">

Same spacing on other lists even with the new CSS rule applied:
<img width="1324" alt="screen shot 2018-09-14 at 9 29 51 pm" src="https://user-images.githubusercontent.com/2396774/45580993-67f33580-b865-11e8-8b26-5d8f4c0de335.png">


