### PR TITLE
Bug: Fixing Mobile Navbar

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -2,18 +2,30 @@
   <div class="masthead__inner-wrap">
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
-        <a class="site-title" href="{{ '/' | absolute_url }}">{{ site.title }}</a>
+        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
         <ul class="visible-links">
           {% for link in site.data.navigation.main[0].children %}
-            {% if link.url contains 'http' %}
-              {% assign domain = '' %}
-            {% else %}
-              {% assign domain = site.url | append: site.baseurl %}
-            {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            {%- if link.url contains '://' -%}
+              {%- assign url = link.url -%}
+            {%- else -%}
+              {%- assign url = link.url | relative_url -%}
+            {%- endif -%}
+            <li class="masthead__menu-item">
+              <a href="{{ url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+            </li>
           {% endfor %}
         </ul>
-        <button><div class="navicon"></div></button>
+        {% if site.search == true %}
+        <button class="search__toggle" type="button">
+          <svg class="icon" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.99 16">
+            <path d="M15.5,13.12L13.19,10.8a1.69,1.69,0,0,0-1.28-.55l-0.06-.06A6.5,6.5,0,0,0,5.77,0,6.5,6.5,0,0,0,2.46,11.59a6.47,6.47,0,0,0,7.74.26l0.05,0.05a1.65,1.65,0,0,0,.5,1.24l2.38,2.38A1.68,1.68,0,0,0,15.5,13.12ZM6.4,2A4.41,4.41,0,1,1,2,6.4,4.43,4.43,0,0,1,6.4,2Z" transform="translate(-.01)"></path>
+          </svg>
+        </button>
+        {% endif %}
+        <button class="greedy-nav__toggle hidden" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle Menu" }}</span>
+          <div class="navicon"></div>
+        </button>
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>

--- a/_sass/child-theme/components/_navigation.scss
+++ b/_sass/child-theme/components/_navigation.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.greedy-nav a {
+  margin: 0 .5rem;
+}
+
 .sidebar {
   @include breakpoint($x-large) {
     width: span(2 of 12);


### PR DESCRIPTION
Fixes #341 

This PR addresses the mobile regression experienced during the latest theme upgrade and described in #341.  We customized one of the files in the theme in order to show sidebar navigation links in the top navigation menu on mobile browsers and during the latest theme upgrade, we didn't incorporate the latest changes in that file, so we had the regression.

This PR integrates the customized include file with the latest theme's code while keeping the same custom functionality.  Included below are some screen captures from my mobile testing after the update was applied:

## Screenshots
### Emulating Chrome on Pixel 2 with mobile nav menu closed
<img width="419" alt="screen shot 2018-10-27 at 6 29 23 am" src="https://user-images.githubusercontent.com/2396774/47604298-ea1e6000-d9b4-11e8-87fc-3179821642a9.png">

### Emulating Chrome on Pixel 2 with mobile nav menu open
<img width="425" alt="screen shot 2018-10-27 at 6 29 15 am" src="https://user-images.githubusercontent.com/2396774/47604303-faced600-d9b4-11e8-8ba8-14b9abf417c6.png">

### Emulating Chrome on Galaxy S5
<img width="384" alt="screen shot 2018-10-27 at 6 28 48 am" src="https://user-images.githubusercontent.com/2396774/47604305-091cf200-d9b5-11e8-9e0f-f2cc9856df6f.png">

### Iphone 6 Chrome
![img_0909](https://user-images.githubusercontent.com/2396774/47604312-2b167480-d9b5-11e8-8912-a1f5c5e030a3.PNG)


### Iphone 6 Safari
![img_0908](https://user-images.githubusercontent.com/2396774/47604316-31a4ec00-d9b5-11e8-8c0e-83534da721da.PNG)
