### PR TITLE
Changing coverage links to v4.5.x

### DIFF
--- a/_posts/2018-08-20-resurrecting-3.md
+++ b/_posts/2018-08-20-resurrecting-3.md
@@ -291,17 +291,17 @@ How could I bridge the gap between these two different environments with incompa
 
 # A roundabout way to convert paths
 
-In the documentation for `coverage`, I noticed that it supported a [`paths` option](https://coverage.readthedocs.io/en/coverage-4.5.2/config.html#paths) that discussed combining paths from multiple filesystems:
+In the documentation for `coverage`, I noticed that it supported a [`paths` option](https://coverage.readthedocs.io/en/v4.5.x/config.html#paths) that discussed combining paths from multiple filesystems:
 
-{% assign fig_caption = "Documentation for [`paths` option](https://coverage.readthedocs.io/en/coverage-4.5.2/config.html#paths) of `coverage` command" | markdownify | remove: "<p>" | remove: "</p>" %}
+{% assign fig_caption = "Documentation for [`paths` option](https://coverage.readthedocs.io/en/v4.5.x/config.html#paths) of `coverage` command" | markdownify | remove: "<p>" | remove: "</p>" %}
 
-{% include image.html file="paths-param.png" alt="Screenshot of paths documentation" fig_caption=fig_caption max_width="712px" link_url="https://coverage.readthedocs.io/en/coverage-4.5.2/config.html#paths" class="img-border" %}
+{% include image.html file="paths-param.png" alt="Screenshot of paths documentation" fig_caption=fig_caption max_width="712px" link_url="https://coverage.readthedocs.io/en/v4.5.x/config.html#paths" class="img-border" %}
 
 To use these options, I created the following `.coveragerc` file:
 
 {% include files.html title="coveragerc" language="ini" %}
 
-My new solution ran the `coverage` command within the Docker container, then executed the [`coverage combine` feature](https://coverage.readthedocs.io/en/coverage-4.5.2/cmd.html#cmd-combining) in the Travis environment, which canonicalized all of the paths to the Travis filesystem.
+My new solution ran the `coverage` command within the Docker container, then executed the [`coverage combine` feature](https://coverage.readthedocs.io/en/v4.5.x/cmd.html#cmd-combining) in the Travis environment, which canonicalized all of the paths to the Travis filesystem.
 
 After applying this solution, the `after_success` section of my [Travis configuration](https://github.com/mtlynch/ingredient-phrase-tagger/blob/9e66f28b07de290b77b1ec0b84baf14f3e7330a0/.travis.yml) looked like this:
 


### PR DESCRIPTION
Hopefully these stay live through version changes because the explicit version numbers break on each release.