### PR TITLE
Re-enabling link checking for RapidAPI

### DIFF
--- a/_tests/build
+++ b/_tests/build
@@ -32,7 +32,6 @@ fi
 #
 # * Ignore vimeo and upwork URLs because they get 403 errors from Travis
 #   intermittently.
-# * Ignore RapidAPI because it's returning 404s for valid URLs.
 bundle exec htmlproofer ./_site \
   --only-4xx \
   --check-favicon \
@@ -41,7 +40,7 @@ bundle exec htmlproofer ./_site \
   --allow-hash-href \
   --empty-alt-ignore \
   --url-swap "https\://mtlynch.io/:/" \
-  --url-ignore "/vimeo.com/,/upwork.com/,/rapidapi.com/" \
+  --url-ignore "/vimeo.com/,/upwork.com/" \
   "$htmlproofer_args_extra"
 
 # Make sure the Google Analytics token appears in the prod build.


### PR DESCRIPTION
It was temporarily returning 404s but it appears to be fixed now.