### PR TITLE
Bug: File embed race condition refactor

### DIFF
--- a/_includes/files.html
+++ b/_includes/files.html
@@ -29,6 +29,12 @@
 {% comment %} Initialize file count. {% endcomment %}
 {% assign file_count = 0 %}
 
+{% comment %} 
+  Initialize an empty string to store unique file paths that match the correct
+  file path and title.
+{% endcomment %}
+{% assign found_files = "" %}
+
 {% for file in files %}
 
   {% comment %}
@@ -70,6 +76,13 @@
     {% assign file_relative_url = file_relative_url | append: '.yml' %}
   {% endif %}
 
+  {% comment %}
+    Check to see if any files have been stored (or found) yet.  If string is
+    empty, set it to the current file's path.
+  {% endcomment %}
+  {% if found_files == "" %}
+    {% assign found_files = file_relative_url %}
+
 ```{{ lang_highlight }}
 {{ file.content -}}
 ```
@@ -78,26 +91,61 @@
 <div class="clearfix">
   <a href="{{ file_relative_url }}" download class="btn--small code-tab">download raw</a>
 </div>
-  {% assign file_count = file_count | plus: 1 %}
+
+  {% else %}
+    {% comment %}
+      Split the found files string into an array and check each entry to
+      see if it is a duplicate of current file.  If it is not a duplicate,
+      then append to the found_files string.  If it is a dupilcate (due to
+      Jekyll admin bug or a different reason) then ignore.
+    {% endcomment %}
+    {% assign already_found = "" %}
+    {% assign found_file_array = found_files | split: ',' %}
+    {% for found_file in found_file_array %}
+      {% if found_file != file_relative_url %}
+        {% assign already_found = file_relative_url %}
+      {% endif %}
+    {% endfor %}
+    {% if already_found != "" %}
+      {% assign found_files = found_files | append: "," | append: already_found %}
+    {% endif %}
+  {% endif %}
 
 {% endfor %}
 
-{% if file_count > 1 %}
-  {% comment %}
-    If there has been more than 1 file with the same title found, then raise an
-    error as this is likely not intentional.
-  {% endcomment %}
-  {{ "Multiple file includes with the same title, "
-    | append: include.title
-    | append: ", have been found."
-    | raise_exception: "warning" }}
-{% elsif file_count == 0 %}
-  {% comment %}
-    If there have been NO files found in the subdirectory that match the title,
-    then raise an error.
-  {% endcomment %}
-  {{ "Zero file includes matched the title, "
-    | append: include.title
-    | append: ".  Please check the file include's title and directory again."
-    | raise_exception: "warning" }}
-{% endif %}
+{% comment %}
+  Determine how many unique files were found for the file embed.  The below
+  table describes the possible scenarios based on the size of the "found_files"
+  string after it is split into an array:
+
+  Size of Array | Error Thrown? | Description
+  -------------------------------------------
+        0       |     Yes       | No matching files were found to embed.
+        1       |     No        | Exactly 1 file was found which is expected.
+        >1      |     Yes       | Duplicate titles found.
+{% endcomment %}
+
+{% comment %} Break string into array for error trapping. {% endcomment %}
+{% assign file_count = found_files | split: ',' | size %}
+
+{% unless file_count == 1 %}
+  {% if file_count == 0 %}
+    {% comment %}
+      If zero files were found in the page's folder that match the file embed
+      title, then raise an error.
+    {% endcomment %}
+    {{ "Zero file includes matched the title, "
+      | append: include.title
+      | append: ".  Please check the file include's title and directory again."
+      | raise_exception: "warning" }}
+  {% else %}
+    {% comment %}
+      If more than 1 file were found in the page's folder that match the file
+      embed title, then raise an error as this is likely not intentional.
+    {% endcomment %}
+    {{ "Multiple file includes with the same title, "
+      | append: include.title
+      | append: ", have been found."
+      | raise_exception: "warning" }}
+  {% endif %}
+{% endunless %}


### PR DESCRIPTION
Fixes #310.

This PR also supercedes #316.

I thought it would be cleaner to submit a distinct PR for the refactoring of the file embed race condition remediation discussed in #316 rather than adding to that existing PR.  If it is desired to keep this all in #316, I can add this to that PR.

This update includes the changes in #316 to remediate the race condition on the file embed include so that false positive errors are not thrown.  This is a "workaround" to the race condition, however, it also ensures duplicate embeds don't happen either so there is progress with this update even if the race condition did not exist.

## What this workaround WILL do
This workaround will:
- [X] Ensure there are no false positives for duplicate file include titles by creating an array of file paths and checking to ensure the same file path is not "counted" as a duplicate file title
- [X] Provide the intended and original functionality for pro-actively finding duplicate and/or incorrect file include titles

## What this workaround DOESN'T do
This workaround doesn't:
- [ ] Address the `conflicting chdir during another chdir block` build warning.  This appears to be at the root of the issue, but again, only occurs when using `Jekyll-admin` for editing content.  So, I believe, the race condition is still present, but doesn't affect how the site is built either for production or when using `Jekll-admin` and with this update, at least false positives are not thrown.
