### PR TITLE
Fixing Twitter cards for book reports

### DIFF
--- a/_book_reports/fooled-by-randomness.md
+++ b/_book_reports/fooled-by-randomness.md
@@ -5,12 +5,14 @@ author_profile: true
 sidebar:
   nav: main
 read_date: 2018-09-04
+header:
+  teaser: /images/book-reports/fooled-by-randomness/fooled-by-randomness.jpg
+  og_image: ""
+report_intro: 
+  score: 5
+  link_title: Amazon link
+  link_url: https://amzn.to/2x2sPT3
 ---
-
-{% include image.html file="fooled-by-randomness.jpg" alt="Fooled by Randomness by Nassim Nicholas Taleb"  link_url="https://amzn.to/2x2sPT3" max_width="250px" class="align-left" %}
-
-* My rating: **5** / 10
-* [Amazon link](https://amzn.to/2x2sPT3)
 
 The book contains many interesting examples of common biases and logical fallacies, but it's buried in a lot of bluster and fluff about how smart the author is. While it was likely groundbreaking when it was published in 2004, its ideas have since permeated into the mainstream. Reading it in 2018, the ideas feel neither novel nor original. [*Thinking Fast and Slow*](https://amzn.to/2oXDdaZ) covers the same material with more depth and better writing.
 

--- a/_book_reports/happy-city.md
+++ b/_book_reports/happy-city.md
@@ -6,12 +6,14 @@ sidebar:
   nav: main
 hide_signup: true
 read_date: 2018-08-06
+header:
+  teaser: /images/book-reports/happy-city/happy-city.jpg
+  og_image: ""
+report_intro: 
+  score: 8
+  link_title: Amazon link
+  link_url: https://amzn.to/2PGxPoU
 ---
-
-{% include image.html file="happy-city.jpg" alt="Happy City by Charles Montgomery"  link_url="https://amzn.to/2PGxPoU" max_width="250px" class="align-left" %}
-
-* My rating: **8** / 10
-* [Amazon link](https://amzn.to/2PGxPoU)
 
 Given how much urban design affects our lives, it's surprising how little we think about and participate in it. This book was eye-opening in terms of the way I look at cities and how its inhabitants interact with them.
 

--- a/_book_reports/start-small-stay-small.md
+++ b/_book_reports/start-small-stay-small.md
@@ -5,12 +5,14 @@ author_profile: true
 sidebar:
   nav: main
 read_date: 2018-11-15
+header:
+  teaser: "/images/book-reports/start-small-stay-small/start-small-stay-small.jpg"
+  og_image: ""
+report_intro: 
+  score: 6
+  link_title: Amazon link
+  link_url: https://amzn.to/2Se9uef
 ---
-
-{% include image.html file="start-small-stay-small.jpg" alt="Start Small, Stay Small by Rob Walling"  link_url="https://amzn.to/2Se9uef" max_width="250px" class="align-left" %}
-
-* My rating: **6** / 10
-* [Amazon link](https://amzn.to/2Se9uef)
 
 I wish that I had found this book nine years ago. It taught me a great deal about choosing the right product to build and the advantages of targeting small niches. The author makes compelling points about the importance of marketing and small founders' common pitfall of treating it as an afterthought.
 

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -44,6 +44,8 @@ en: &DEFAULT_EN
   email_form_subheader       : "Subscribe to get my latest articles by email."
   email_form_email_label     : "Email address"
   email_form_btn_submit      : "Subscribe"
+  book_report_rating         : "My rating:"
+  book_report_rating_limit   : "10"
 en-US:
   <<: *DEFAULT_EN
 en-CA:

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -37,6 +37,26 @@ layout: default
       {% endunless %}
 
       <section class="page__content" itemprop="text">
+        {% comment %}
+          If the page is a book report, then add the book report intro section.
+        {% endcomment %}
+        {% if page.collection == "book_reports" %}
+          {% comment %}
+            If the page's og_image frontmatter value exists use that for the
+            report image, otherwise fallback to the teaser value.
+          {% endcomment %}
+          {%- assign book_report_image = page.header.og_image | default: page.header.teaser -%}
+          <p class="book-report-intro">
+            <a href="{{ page.report_intro.link_url }}">
+              <img src="{{ book_report_image }}" alt="{{ page.title }}" class="align-left">
+            </a>
+          </p>
+          <ul>
+            <li>{{ site.data.ui-text[site.locale].book_report_rating | default: "My rating:" }} <strong>{{ page.report_intro.score }}</strong> / {{ site.data.ui-text[site.locale].book_report_rating_limit | default: "My rating:" }}</li>
+            <li><a href="{{ page.report_intro.link_url }}">{{ page.report_intro.link_title }}</a></li>
+          </ul>
+        {% endif %}
+
         {{ content }}
 
         {% if page.link %}<div><a href="{{ page.link }}" class="btn">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}

--- a/_linter/frontmatter-tests/_book_reports.yml
+++ b/_linter/frontmatter-tests/_book_reports.yml
@@ -1,0 +1,14 @@
+---
+header:
+  type: "Dictionary"
+  key: "teaser"
+  key-type: "String"
+config:
+  path: _book_reports
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['']
+---

--- a/_sass/child-theme/_main.scss
+++ b/_sass/child-theme/_main.scss
@@ -18,6 +18,7 @@
 // Including individual components
 @import 'components/ads';
 @import 'components/anchors';
+@import 'components/book_reports';
 @import 'components/buttons';
 @import 'components/code-block';
 @import 'components/figures';

--- a/_sass/child-theme/components/_book_reports.scss
+++ b/_sass/child-theme/components/_book_reports.scss
@@ -1,0 +1,7 @@
+// Book Report Intro Classes
+
+.book-report-intro {
+  img {
+    max-width:250px
+  }
+}


### PR DESCRIPTION
Fixes #359 

This update is my approach to fixing the twitter cards for the book reports collection to meet what is requested in #359.  This approach:

- Moves the book cover image to the theme's pre-defined frontmatter fields for twitter and open graph images.  So, instead of defining the book cover image in the markdown, defining it in the theme's pre-defined frontmatter fields for open graph and social media sharing resolves the problem of no image/the site's default image displaying in Twitter cards.
- Because the move to using frontmatter fields for the book cover, we also need to add logic to the html template to render the image in the necessary part of the book report page as well.
- Finally, to ensure the book's rating scores and Amazon links are not included in the text of the Twitter card, we can similarly move this to using yaml frontmatter as well.

## Other Notes
- I also added a book report schema for validating `header.teaser` frontmatter values as that should probably always be defined even if null.  We may want to consider validating for the `header.og_image` , `report_intro.score`, `report_intro.link_title`, and `report_intro.link_url` as well.  But I think it's probably best to ensure the approach is amenable from an overall perspective.
- It seems like currently, the alt tag for the book cover image is always the value of the `title` yaml value so I used that in the template.

## Screenshot of locally validating twitter card

<img width="524" alt="screen shot 2019-02-05 at 9 15 06 pm" src="https://user-images.githubusercontent.com/2396774/52319322-13c52b00-2997-11e9-9615-601b6b28371c.png">
