### PR TITLE
Fixing Twitter cards for book reports - Take 2

### DIFF
--- a/_book_reports/fooled-by-randomness.md
+++ b/_book_reports/fooled-by-randomness.md
@@ -5,12 +5,14 @@ author_profile: true
 sidebar:
   nav: main
 read_date: 2018-09-04
+header:
+  teaser: /images/book-reports/fooled-by-randomness/fooled-by-randomness.jpg
+  og_image: ""
+report_intro: 
+  score: 5
+  link_title: Amazon link
+  link_url: https://amzn.to/2x2sPT3
 ---
-
-{% include image.html file="fooled-by-randomness.jpg" alt="Fooled by Randomness by Nassim Nicholas Taleb"  link_url="https://amzn.to/2x2sPT3" max_width="250px" class="align-left" %}
-
-* My rating: **5** / 10
-* [Amazon link](https://amzn.to/2x2sPT3)
 
 The book contains many interesting examples of common biases and logical fallacies, but it's buried in a lot of bluster and fluff about how smart the author is. While it was likely groundbreaking when it was published in 2004, its ideas have since permeated into the mainstream. Reading it in 2018, the ideas feel neither novel nor original. [*Thinking Fast and Slow*](https://amzn.to/2oXDdaZ) covers the same material with more depth and better writing.
 

--- a/_book_reports/fooled-by-randomness.md
+++ b/_book_reports/fooled-by-randomness.md
@@ -7,10 +7,8 @@ sidebar:
 read_date: 2018-09-04
 header:
   teaser: /images/book-reports/fooled-by-randomness/fooled-by-randomness.jpg
-  og_image: ""
-report_intro: 
+report_intro:
   score: 5
-  link_title: Amazon link
   link_url: https://amzn.to/2x2sPT3
 ---
 

--- a/_book_reports/happy-city.md
+++ b/_book_reports/happy-city.md
@@ -6,12 +6,14 @@ sidebar:
   nav: main
 hide_signup: true
 read_date: 2018-08-06
+header:
+  teaser: /images/book-reports/happy-city/happy-city.jpg
+  og_image: ""
+report_intro: 
+  score: 8
+  link_title: Amazon link
+  link_url: https://amzn.to/2PGxPoU
 ---
-
-{% include image.html file="happy-city.jpg" alt="Happy City by Charles Montgomery"  link_url="https://amzn.to/2PGxPoU" max_width="250px" class="align-left" %}
-
-* My rating: **8** / 10
-* [Amazon link](https://amzn.to/2PGxPoU)
 
 Given how much urban design affects our lives, it's surprising how little we think about and participate in it. This book was eye-opening in terms of the way I look at cities and how its inhabitants interact with them.
 

--- a/_book_reports/happy-city.md
+++ b/_book_reports/happy-city.md
@@ -8,10 +8,8 @@ hide_signup: true
 read_date: 2018-08-06
 header:
   teaser: /images/book-reports/happy-city/happy-city.jpg
-  og_image: ""
-report_intro: 
+report_intro:
   score: 8
-  link_title: Amazon link
   link_url: https://amzn.to/2PGxPoU
 ---
 

--- a/_book_reports/start-small-stay-small.md
+++ b/_book_reports/start-small-stay-small.md
@@ -7,10 +7,8 @@ sidebar:
 read_date: 2018-11-15
 header:
   teaser: "/images/book-reports/start-small-stay-small/start-small-stay-small.jpg"
-  og_image: ""
-report_intro: 
+report_intro:
   score: 6
-  link_title: Amazon link
   link_url: https://amzn.to/2HZT8lA
 ---
 

--- a/_book_reports/start-small-stay-small.md
+++ b/_book_reports/start-small-stay-small.md
@@ -5,12 +5,14 @@ author_profile: true
 sidebar:
   nav: main
 read_date: 2018-11-15
+header:
+  teaser: "/images/book-reports/start-small-stay-small/start-small-stay-small.jpg"
+  og_image: ""
+report_intro: 
+  score: 6
+  link_title: Amazon link
+  link_url: https://amzn.to/2Se9uef
 ---
-
-{% include image.html file="start-small-stay-small.jpg" alt="Start Small, Stay Small by Rob Walling"  link_url="https://amzn.to/2HZT8lA" max_width="250px" class="align-left" %}
-
-* My rating: **6** / 10
-* [Amazon link](https://amzn.to/2HZT8lA)
 
 I wish that I had found this book nine years ago. It taught me a great deal about choosing the right product to build and the advantages of targeting small niches. The author makes compelling points about the importance of marketing and small founders' common pitfall of treating it as an afterthought.
 

--- a/_book_reports/start-small-stay-small.md
+++ b/_book_reports/start-small-stay-small.md
@@ -11,7 +11,7 @@ header:
 report_intro: 
   score: 6
   link_title: Amazon link
-  link_url: https://amzn.to/2Se9uef
+  link_url: https://amzn.to/2HZT8lA
 ---
 
 I wish that I had found this book nine years ago. It taught me a great deal about choosing the right product to build and the advantages of targeting small niches. The author makes compelling points about the importance of marketing and small founders' common pitfall of treating it as an afterthought.

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -38,17 +38,7 @@
     {% endif %}
     {% if post.collection == "book_reports" %}
       <hr />
-
-      {% comment %}
-        Split the post's excerpt into two parts using the unordered list element
-        in order to insert the link to the full notes as the last list item
-        inside the unordered list.
-      {% endcomment %}
-      {% assign contentArray = post.excerpt | split: '</ul>' %}
-      {{ contentArray.first }}
-      <li><a href="{{ post.url }}" class="full-notes">Full notes</a></li>
-      {{ contentArray.last | prepend: '</ul>' }}
-
+      {% include book-report-introduction.html %}
     {% elsif post.excerpt %}
       <p class="archive__item-excerpt" itemprop="description">
         {{ post.excerpt | markdownify | strip_html | truncate: 160 }}

--- a/_includes/book-report-introduction.html
+++ b/_includes/book-report-introduction.html
@@ -1,0 +1,40 @@
+{% comment %}
+  Book Report Introduction Include
+
+  This include file contains a common layout module that is used on the book
+  reports index page and the individual book report pages.
+{% endcomment %}
+
+{% comment %}
+  Determine the proper content classification to used for displaying the item's
+  metadata.
+{% endcomment %}
+{% if page.url == "/book-reports/" %}
+  {% assign metadata = post %}
+{% else %}
+  {% assign metadata = page %}
+{% endif %}
+
+{% comment %}
+  If the page's og_image frontmatter value exists use that for the report image,
+  otherwise fallback to the teaser value.
+{% endcomment %}
+{%- assign book_report_image = metadata.header.og_image | default: metadata.header.teaser -%}
+
+<p class="book-report-intro">
+  <a href="{{ metadata.report_intro.link_url }}">
+    <img src="{{ book_report_image }}" alt="{{ metadata.title }}" class="align-left">
+  </a>
+</p>
+<ul>
+  <li>My rating: <strong>{{ metadata.report_intro.score }}</strong> / 10</li>
+  <li><a href="{{ metadata.report_intro.link_url }}">{{ metadata.report_intro.link_title }}</a></li>
+  {% if page.url == "/book-reports/" %}
+    <li><a href="{{ metadata.url }}" class="full-notes">Full notes</a></li>
+  {% endif %}
+</ul>
+
+{% if page.url == "/book-reports/" %}
+  {{ metadata.excerpt | markdownify }}
+  <p class="clearfix"></p>
+{% endif %}

--- a/_includes/book-report-introduction.html
+++ b/_includes/book-report-introduction.html
@@ -15,20 +15,14 @@
   {% assign metadata = page %}
 {% endif %}
 
-{% comment %}
-  If the page's og_image frontmatter value exists use that for the report image,
-  otherwise fallback to the teaser value.
-{% endcomment %}
-{%- assign book_report_image = metadata.header.og_image | default: metadata.header.teaser -%}
-
 <p class="book-report-intro">
   <a href="{{ metadata.report_intro.link_url }}">
-    <img src="{{ book_report_image }}" alt="{{ metadata.title }}" class="align-left">
+    <img src="{{ metadata.header.teaser }}" alt="{{ metadata.title }}" class="align-left">
   </a>
 </p>
 <ul>
   <li>My rating: <strong>{{ metadata.report_intro.score }}</strong> / 10</li>
-  <li><a href="{{ metadata.report_intro.link_url }}">{{ metadata.report_intro.link_title }}</a></li>
+  <li><a href="{{ metadata.report_intro.link_url }}"> Amazon link</a></li>
   {% if page.url == "/book-reports/" %}
     <li><a href="{{ metadata.url }}" class="full-notes">Full notes</a></li>
   {% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -37,6 +37,13 @@ layout: default
       {% endunless %}
 
       <section class="page__content" itemprop="text">
+        {% comment %}
+          If the page is a book report, then add the book report intro section.
+        {% endcomment %}
+        {% if page.collection == "book_reports" %}
+          {% include book-report-introduction.html %}
+        {% endif %}
+
         {{ content }}
 
         {% if page.link %}<div><a href="{{ page.link }}" class="btn">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}

--- a/_linter/frontmatter-tests/_book_reports.yml
+++ b/_linter/frontmatter-tests/_book_reports.yml
@@ -1,0 +1,14 @@
+---
+header:
+  type: "Dictionary"
+  key: "teaser"
+  key-type: "String"
+config:
+  path: _book_reports
+  ignore:
+  - README.md
+  - ..
+  - .
+  - .DS_Store
+  optional: ['']
+---

--- a/_sass/child-theme/_main.scss
+++ b/_sass/child-theme/_main.scss
@@ -18,6 +18,7 @@
 // Including individual components
 @import 'components/ads';
 @import 'components/anchors';
+@import 'components/book_reports';
 @import 'components/buttons';
 @import 'components/code-block';
 @import 'components/figures';

--- a/_sass/child-theme/components/_book_reports.scss
+++ b/_sass/child-theme/components/_book_reports.scss
@@ -1,0 +1,7 @@
+// Book Report Intro Classes
+
+.book-report-intro {
+  img {
+    max-width:250px
+  }
+}


### PR DESCRIPTION
Fixes #359 

This update is my approach to fixing the twitter cards for the book reports collection to meet what is requested in #359.  This approach:

- Moves the book cover image to the theme's pre-defined frontmatter fields for twitter and open graph images.  So, instead of defining the book cover image in the markdown, defining it in the theme's pre-defined frontmatter fields for open graph and social media sharing resolves the problem of no image/the site's default image displaying in Twitter cards.
- Because we move these fields into the frontmatter, it changes how we get the information for the book report index & individual pages for display.  Since the layouts are so similar, I think it would be best to abstract that to it's own include to reduce redundancy.  So we have a new include called `includes/book-report-introduction.html` that contains that template & logic.

## Other Notes
- I also added a book report schema for validating `header.teaser` frontmatter values as that should probably always be defined even if null.  We may want to consider validating for the `header.og_image` , `report_intro.score`, `report_intro.link_title`, and `report_intro.link_url` as well.  But I think it's probably best to ensure the approach is amenable from an overall perspective.
- It seems like currently, the alt tag for the book cover image is always the value of the `title` yaml value so I used that in the template.

## Screenshot of locally validating twitter card

<img width="524" alt="screen shot 2019-02-05 at 9 15 06 pm" src="https://user-images.githubusercontent.com/2396774/52319322-13c52b00-2997-11e9-9615-601b6b28371c.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/mtlynch.io/364)
<!-- Reviewable:end -->
