### PR TITLE
Adding a build check for Amazon affiliate IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ codekit-config.json
 node_modules
 npm-debug.log*
 *.swp
+*.swo
 _*preview*
 _update_date.py
 assets/js/main.min.js

--- a/_book_reports/start-small-stay-small.md
+++ b/_book_reports/start-small-stay-small.md
@@ -7,10 +7,10 @@ sidebar:
 read_date: 2018-11-15
 ---
 
-{% include image.html file="start-small-stay-small.jpg" alt="Start Small, Stay Small by Rob Walling"  link_url="https://amzn.to/2Se9uef" max_width="250px" class="align-left" %}
+{% include image.html file="start-small-stay-small.jpg" alt="Start Small, Stay Small by Rob Walling"  link_url="https://amzn.to/2HZT8lA" max_width="250px" class="align-left" %}
 
 * My rating: **6** / 10
-* [Amazon link](https://amzn.to/2Se9uef)
+* [Amazon link](https://amzn.to/2HZT8lA)
 
 I wish that I had found this book nine years ago. It taught me a great deal about choosing the right product to build and the advantages of targeting small niches. The author makes compelling points about the importance of marketing and small founders' common pitfall of treating it as an afterthought.
 

--- a/_tests/build
+++ b/_tests/build
@@ -4,6 +4,8 @@
 set -e
 # Echo commands to console.
 set -x
+# Exit on unset variable.
+set -u
 
 # Execute Frontmatter Tests
 BUNDLE_GEMFILE=Gemfile bundle exec jekyll yml-test
@@ -66,4 +68,12 @@ fi
 if ! egrep "\"twitter:card.*summary_large_image\"" _site/ -R; then
   echo "ERROR: Large Twitter cards didn't appear in prod build!";
   exit 1;
+fi
+
+# Check that Amazon links have the right affiliate ID.
+if [ "$1" = "--quick" ]; then
+  echo "Skipping Amazon link check..."
+else
+  echo "Checking Amazon links..."
+  ./check_amazon_links
 fi

--- a/_tests/build
+++ b/_tests/build
@@ -75,5 +75,5 @@ if [ "${1-}" = "--quick" ]; then
   echo "Skipping Amazon link check..."
 else
   echo "Checking Amazon links..."
-  ./check_amazon_links
+  ./_tests/check_amazon_links
 fi

--- a/_tests/build
+++ b/_tests/build
@@ -31,7 +31,7 @@ BUNDLE_GEMFILE=Gemfile JEKYLL_ENV=production bundle exec jekyll build \
 
 # Skips validation checks that take a long time
 htmlproofer_args_extra=""
-if [ "$1" = "--quick" ]; then
+if [ "${1-}" = "--quick" ]; then
   htmlproofer_args_extra="--disable-external"
 else
   htmlproofer_args_extra="--check-external-hash"
@@ -71,7 +71,7 @@ if ! egrep "\"twitter:card.*summary_large_image\"" _site/ -R; then
 fi
 
 # Check that Amazon links have the right affiliate ID.
-if [ "$1" = "--quick" ]; then
+if [ "${1-}" = "--quick" ]; then
   echo "Skipping Amazon link check..."
 else
   echo "Checking Amazon links..."

--- a/_tests/check_amazon_links
+++ b/_tests/check_amazon_links
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Checks that Amazon links have the correct tracking ID for this blog.
+
+# Exit on first failing command.
+set -e
+# Exit on unset variable.
+set -u
+
+AMAZON_AFFILIATE_ID=mtlynch-20
+
+shortlinks=$(
+  egrep \
+    --dereference-recursive \
+    --only-matching \
+    --no-filename \
+    --binary-files=without-match \
+    "https?://amzn.to/[^\?\&\"\)]+" \
+    _site/ | uniq
+  )
+echo $(echo "$shortlinks" | wc -l) " Amazon links to check"
+
+for url in $shortlinks; do
+  url_effective=$(
+    curl $url \
+      --silent \
+      --location \
+      --head \
+      --output /dev/null \
+      --write-out '%{url_effective}'
+   )
+  if ! echo "$url_effective" | grep $AMAZON_AFFILIATE_ID; then
+    echo "ERROR: Amazon URL missing expected" \
+         "affiliate ID (${AMAZON_AFFILIATE_ID}): $url_effective";
+    exit 1;
+  fi
+done
+


### PR DESCRIPTION
And fixing an instance where I used a shortlink with the wrong ID