### PR TITLE
Revert "Adding --force_polling flag to _serve_dev_site scripte (#401)"

### DIFF
--- a/_serve_dev_site
+++ b/_serve_dev_site
@@ -11,5 +11,4 @@ bundle exec jekyll serve \
   --config _config.yml,_config_dev.yml \
   --livereload \
   --watch \
-  --force_polling \
   --incremental


### PR DESCRIPTION
This reverts commit 36d373390e9148015e07949ababfbf29dc319057. It
balloons incremental builds from 3 seconds to around 90-120 seconds,
which is a dealbreaker.