### PR TITLE
Adding affiliate link disclosure

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,5 +9,7 @@
     {{ else }}
       · © {{ now.Year }}
     {{ end }}
+
+    <i>Disclosure: This blog uses affiliate tags for some product links. This allows the blog to receive a commission when readers make purchases through these links.</i>
   </section>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,9 @@
 <footer class="footer">
   <section class="container">
+    <p class="affiliate-disclosure">
+      <i>Disclosure: Some links on this site contain affiliate tags. Purchases you make through these links may result in the merchant paying this site a commission, though these commissions never affect the price that you pay.</i>
+    </p>
+
     {{ with .Site.Params.footercontent | safeHTML }}
       <p>{{.}}</p>
     {{ end }}
@@ -9,7 +13,5 @@
     {{ else }}
       · © {{ now.Year }}
     {{ end }}
-
-    <i>Disclosure: This blog uses affiliate tags for some product links. This allows the blog to receive a commission when readers make purchases through these links.</i>
   </section>
 </footer>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -474,3 +474,10 @@ h4:hover .hanchor {
     margin: 0 3rem 0 0 !important;
   }
 }
+
+.affiliate-disclosure {
+  margin-bottom: 5rem;
+  padding: 2rem 1rem;
+  background-color: rgb(245, 252, 240);
+  border: 1px solid rgb(166, 224, 166);
+}


### PR DESCRIPTION
It apparently got dropped during the Jekyll -> Hugo migration
