### PR TITLE
Remove Amazon OneLink from page template

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -111,7 +111,6 @@
     </main>
 
     {{ partial "google-analytics.html" . }}
-    {{ partial "amazon-onelink.html" }}
 
   </body>
 

--- a/layouts/partials/amazon-onelink.html
+++ b/layouts/partials/amazon-onelink.html
@@ -1,3 +1,0 @@
-<!-- Amazon OneLink snippet -->
-<div id="amzn-assoc-ad-1b864722-ce8b-45d9-89b5-0c7b92a1d87b"></div>
-<script async src="//z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US&adInstanceId=1b864722-ce8b-45d9-89b5-0c7b92a1d87b"></script>


### PR DESCRIPTION
Affiliate links were removed in c6f0b2181ccf1d7b5184a4db814b02af0efbbb76 so this is no longer useful