### PR TITLE
Fix bug in currency formatting

### DIFF
--- a/content/posts/solo-developer-year-3/index.md
+++ b/content/posts/solo-developer-year-3/index.md
@@ -309,6 +309,7 @@ Once again, I feel incredibly fortunate to be working for myself, and I hope to 
 const dollarFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
+  minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 });
 function drawChart(chartId, labels, data) {

--- a/layouts/partials/retrospectives/page.html
+++ b/layouts/partials/retrospectives/page.html
@@ -39,6 +39,7 @@
 const dollarFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
+  minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 });
 function drawChart(chartId, labels, data) {


### PR DESCRIPTION
Some browsers apparently require both minimum and maximum fraction digits specified