### PR TITLE
Disable Hugo canonify URLs setting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,8 +5,11 @@ languagecode = "en"
 defaultcontentlanguage = "en"
 
 paginate = 10
-canonifyurls = true
 timeout = 120000
+
+# We don't want to canonify URLs because it prevents us from
+# deploying drafts of the site to alternate hosts.
+canonifyurls = false
 
 pygmentsstyle = "colorful"
 pygmentscodefences = true


### PR DESCRIPTION
From the docs: In the May 2014 release of Hugo v0.11, the default value of canonifyURLs was switched from true to false, which we think is the better default and should continue to be the case going forward. Please verify and adjust your website accordingly if you are upgrading from v0.10 or older versions.

https://gohugo.io/content-management/urls/#canonicalization

I don't recall why I ever picked canonifyurls = true in the first place, so I'm switching it to the relative way so it's easy to deploy draft versions to temporary domains.