### PR TITLE
Remove hardcoded site baseURL from CSS routes

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,13 +26,13 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
     {{ if .HasShortcode "zestful-ad" }}
-      <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/zestful.css" media="screen">
+      <link rel="stylesheet" href="/css/zestful.css" media="screen">
     {{ end }}
     {{ if .HasShortcode "tinypilot-ad" }}
-      <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/tinypilot.css" media="screen">
+      <link rel="stylesheet" href="/css/tinypilot.css" media="screen">
     {{ end }}
     {{ if .HasShortcode "htfp-ad" }}
-      <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/htfp.css" media="screen">
+      <link rel="stylesheet" href="/css/htfp.css" media="screen">
     {{ end }}
 
     {{ if .Site.IsServer }}


### PR DESCRIPTION
We don't need them, and it interferes with hosting drafts on other domains.