### PR TITLE
Remove dead amazon link to HDMI to USB dongle

### DIFF
--- a/content/posts/tinypilot/index.md
+++ b/content/posts/tinypilot/index.md
@@ -99,7 +99,7 @@ Fortunately, I found a better solution by complete coincidence.
 
 ### HDMI to USB dongle
 
-While mindlessly scrolling through Twitter, I happened to see [a tweet by Arsenio Dev](https://twitter.com/Ascii211/status/1268631069051453448) about a [low-cost HDMI to USB dongle](https://smile.amazon.com/Camcorder-Definition-Acquisition-Broadcasting-Conference/dp/B08B4J2XXF/) he had just purchased:
+While mindlessly scrolling through Twitter, I happened to see [a tweet by Arsenio Dev](https://twitter.com/Ascii211/status/1268631069051453448) about a low-cost HDMI to USB dongle he had just purchased:
 
 {{<img src="arsenio-dev-tweet.jpg" alt="Screenshot of Rufus" caption="A [tweet from Arsenio Dev](https://twitter.com/Ascii211/status/1268631069051453448) tipped me off to a better video capture solution." linkUrl="https://twitter.com/Ascii211/status/1268631069051453448">}}
 
@@ -138,7 +138,7 @@ ffplay.exe -i udp://@10.0.0.100:1234/stream
 
 It was so darn convenient, too. The LKV373A was nearly brick-sized and required its own power source and Ethernet cable. The HDMI dongle was as small as a thumb drive and required nothing more than a USB port.
 
-{{<img src="lkv373a-vs-dongle.jpg" alt="Comparison of Lenkeng LKV373A with HDMI dongle" caption="The [Lenkeng LKV373A HDMI extender](https://smile.amazon.com/AEMYO-Extender-V3-0-Ethernet-Supports/dp/B01LGUT9HW/) (left) was larger and required more connections than the [HDMI dongle](https://smile.amazon.com/Camcorder-Definition-Acquisition-Broadcasting-Conference/dp/B08B4J2XXF/) (right)." maxWidth="700px">}}
+{{<img src="lkv373a-vs-dongle.jpg" alt="Comparison of Lenkeng LKV373A with HDMI dongle" caption="The [Lenkeng LKV373A HDMI extender](https://smile.amazon.com/AEMYO-Extender-V3-0-Ethernet-Supports/dp/B01LGUT9HW/) (left) was larger and required more connections than the HDMI dongle (right)." maxWidth="700px">}}
 
 The only problem was, again, latency. The Pi's rebroadcast of the video stream lagged the source computer by 7-10 seconds.
 

--- a/tests/lint-html
+++ b/tests/lint-html
@@ -33,7 +33,7 @@ htmlproofer "$BUILD_DIR" \
   --url-swap "https\://mtlynch.io/:/" \
   `# Ignore the following URLs because they get 403 errors from CI` \
   `# intermittently.` \
-  --url-ignore "/vimeo.com/,/upwork.com/,/www.amd.com/,/mediagoblin-v5lmqis51k.herokuapp.com/,/servernope.com/,/gusto.com/,/vmware.com/,/medium.com/,/web.archive.org/" \
+  --url-ignore "/vimeo.com/,/upwork.com/,/www.amd.com/,/mediagoblin-v5lmqis51k.herokuapp.com/,/servernope.com/,/gusto.com/,/vmware.com/,/medium.com/,/typeform.com/" \
   `# Some sites return HTTP 400/429 - No Error when HTMLProofer sends ` \
   `# requests, so ignore those.` \
   --http-status-ignore "400,429" \


### PR DESCRIPTION
Also drops the archive.org link check suppression.

Fixes #856