### PR TITLE
Drop lint-html as a requirement for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ workflows:
             - check-whitespace
             - lint-markdown
             - build
-            - lint-html
             - check-seo-metadata
           filters:
             branches:


### PR DESCRIPTION
This makes it easier to override transient errors that show up as dead links.