### PR TITLE
Add sciencedirect.com to list of ignored html-lint URLs

### DIFF
--- a/tests/lint-html
+++ b/tests/lint-html
@@ -17,6 +17,27 @@ else
   htmlproofer_args_extra="--check-external-hash"
 fi
 
+function join_by {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+# Ignore the following URLs because they get 403 errors from CI intermittently.
+IGNORE_PATTERNS=()
+IGNORE_PATTERNS+=("/vimeo.com/")
+IGNORE_PATTERNS+=("/upwork.com/")
+IGNORE_PATTERNS+=("/www.amd.com/")
+IGNORE_PATTERNS+=("/mediagoblin-v5lmqis51k.herokuapp.com/")
+IGNORE_PATTERNS+=("/servernope.com/")
+IGNORE_PATTERNS+=("/gusto.com/")
+IGNORE_PATTERNS+=("/vmware.com/")
+IGNORE_PATTERNS+=("/medium.com/")
+IGNORE_PATTERNS+=("/typeform.com/")
+IGNORE_PATTERNS+=("/www.sciencedirect.com/")
+
+URL_IGNORE="$(join_by , "${IGNORE_PATTERNS[@]}")"
+
 # Run HTMLProofer
 htmlproofer "$BUILD_DIR" \
   --only-4xx \
@@ -31,9 +52,7 @@ htmlproofer "$BUILD_DIR" \
   `# site has not yet deployed, so htmlproofer shouldn't try to hit the real` \
   `# mtlynch.io server to verify that URLs are present.` \
   --url-swap "https\://mtlynch.io/:/" \
-  `# Ignore the following URLs because they get 403 errors from CI` \
-  `# intermittently.` \
-  --url-ignore "/vimeo.com/,/upwork.com/,/www.amd.com/,/mediagoblin-v5lmqis51k.herokuapp.com/,/servernope.com/,/gusto.com/,/vmware.com/,/medium.com/,/typeform.com/" \
+  --url-ignore "${URL_IGNORE}" \
   `# Some sites return HTTP 400/429 - No Error when HTMLProofer sends ` \
   `# requests, so ignore those.` \
   --http-status-ignore "400,429" \


### PR DESCRIPTION
And also, refactor the way we manage the list.