### PR TITLE
Ignore 403 from Github dev docs during html-lint

### DIFF
--- a/tests/lint-html
+++ b/tests/lint-html
@@ -35,6 +35,8 @@ IGNORE_PATTERNS+=("/vmware.com/")
 IGNORE_PATTERNS+=("/medium.com/")
 IGNORE_PATTERNS+=("/typeform.com/")
 IGNORE_PATTERNS+=("/www.sciencedirect.com/")
+IGNORE_PATTERNS+=("/developer.github.com/")
+IGNORE_PATTERNS+=("/docs.github.com/")
 
 URL_IGNORE="$(join_by , "${IGNORE_PATTERNS[@]}")"
 


### PR DESCRIPTION
They seem to be blocking requests from CI now.