### PR TITLE
Add slash after baseurl in NixOS Pi 4 tutorial

### DIFF
--- a/content/posts/nixos-pi4/index.md
+++ b/content/posts/nixos-pi4/index.md
@@ -152,7 +152,7 @@ To make your NixOS experience more interesting, install a desktop GUI and a few 
 curl \
   --show-error \
   --fail \
-  {{<baseurl>}}nixos-pi4/configuration.nix \
+  {{<baseurl>}}/nixos-pi4/configuration.nix \
   | sudo tee /etc/nixos/configuration.nix
 ```
 


### PR DESCRIPTION
Strangely, it renders correctly on local but not in production without the slash