### PR TITLE
Use the -nixpkgs convention instead of _dep

### DIFF
--- a/content/notes/nix-dev-environment/flake.nix
+++ b/content/notes/nix-dev-environment/flake.nix
@@ -5,20 +5,20 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     # 2.7.18.7 release
-    python_dep.url = "github:NixOS/nixpkgs/517501bcf14ae6ec47efd6a17dda0ca8e6d866f9";
+    python-nixpkgs.url = "github:NixOS/nixpkgs/517501bcf14ae6ec47efd6a17dda0ca8e6d866f9";
   };
 
   outputs = {
     self,
     flake-utils,
-    python_dep,
+    python-nixpkgs,
   } @ inputs:
     flake-utils.lib.eachDefaultSystem (system: let
-      python_dep = inputs.python_dep.legacyPackages.${system};
+      python-nixpkgs = inputs.python-nixpkgs.legacyPackages.${system};
     in {
-      devShells.default = python_dep.mkShell {
+      devShells.default = python-nixpkgs.mkShell {
         packages = [
-          python_dep.python2
+          python-nixpkgs.python2
         ];
 
         shellHook = ''

--- a/content/notes/zig-call-c-simple/index.md
+++ b/content/notes/zig-call-c-simple/index.md
@@ -103,18 +103,18 @@ I added the following `flake.nix` file to my project, which pulls Zig 0.11.0 int
     flake-utils.url = "github:numtide/flake-utils";
 
     # 0.11.0
-    zig_dep.url = "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e";
+    zig-nixpkgs.url = "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e";
   };
 
-  outputs = { self, flake-utils, zig_dep }@inputs :
+  outputs = { self, flake-utils, zig-nixpkgs }@inputs :
     flake-utils.lib.eachDefaultSystem (system:
     let
-      zig_dep = inputs.zig_dep.legacyPackages.${system};
+      zig-nixpkgs = inputs.zig-nixpkgs.legacyPackages.${system};
     in
     {
-      devShells.default = zig_dep.mkShell {
+      devShells.default = zig-nixpkgs.mkShell {
         packages = [
-          zig_dep.zig
+          zig-nixpkgs.zig
         ];
 
         shellHook = ''

--- a/content/notes/zig-unit-test-c/index.md
+++ b/content/notes/zig-unit-test-c/index.md
@@ -162,18 +162,18 @@ I added the following `flake.nix` file to my project, which pulls Zig 0.11.0 int
     flake-utils.url = "github:numtide/flake-utils";
 
     # 0.11.0
-    zig_dep.url = "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e";
+    zig-nixpkgs.url = "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e";
   };
 
-  outputs = { self, flake-utils, zig_dep }@inputs :
+  outputs = { self, flake-utils, zig-nixpkgs }@inputs :
     flake-utils.lib.eachDefaultSystem (system:
     let
-      zig_dep = inputs.zig_dep.legacyPackages.${system};
+      zig-nixpkgs = inputs.zig-nixpkgs.legacyPackages.${system};
     in
     {
-      devShells.default = zig_dep.mkShell {
+      devShells.default = zig-nixpkgs.mkShell {
         packages = [
-          zig_dep.zig
+          zig-nixpkgs.zig
         ];
 
         shellHook = ''


### PR DESCRIPTION
The clearer naming convention for nixpkgs is to use the suffix -nixpkgs rather than _dep