### PR TITLE
In NixOS Oracle tutorial, include disko in configuration.nix

### DIFF
--- a/content/notes/nix-oracle-cloud/configuration.nix
+++ b/content/notes/nix-oracle-cloud/configuration.nix
@@ -7,6 +7,8 @@ in
   imports =
     [
       ./hardware-configuration.nix
+      "${builtins.fetchTarball "https://github.com/nix-community/disko/archive/v1.11.0.tar.gz"}/module.nix"
+     ./disk-config.nix
     ];
 
   boot = {


### PR DESCRIPTION
I must have deleted these lines by mistake.