### PR TITLE
Reduce responsive image waste

### DIFF
--- a/layouts/partials/responsive-img.html
+++ b/layouts/partials/responsive-img.html
@@ -1,30 +1,76 @@
 {{/* Partial for generating responsive images with srcset
   Parameters:
   - .image: Hugo image resource
-  - .sizes: sizes attribute value (optional, defaults to responsive)
+  - .maxDisplayWidth: maximum rendered image width in CSS pixels
+  - .photoWidths: configured responsive image widths
+  - .sizes: sizes attribute value
+  - .alt: alt attribute value (optional)
   - .class: CSS class for the img tag (optional)
   - .loading: loading attribute (optional, defaults to "lazy")
 */}}
 
 {{ $image := .image }}
-{{ $sizes := .sizes | default "(min-width: 768px) 400px, 98vw" }}
+{{ $maxDisplayWidth := int .maxDisplayWidth }}
+{{ if gt $maxDisplayWidth $image.Width }}
+  {{ $maxDisplayWidth = $image.Width }}
+{{ end }}
+{{ $maxCandidateWidth := mul $maxDisplayWidth 2 }}
+{{ if gt $maxCandidateWidth $image.Width }}
+  {{ $maxCandidateWidth = $image.Width }}
+{{ end }}
+
+{{ $sizes := .sizes }}
+{{ $alt := .alt | default "" }}
 {{ $class := .class | default "" }}
 {{ $loading := .loading | default "lazy" }}
 
-{{ $srcset := "" }}
-{{ range .photoWidths }}
-  {{- if le . $image.Width }}
+{{ $candidates := slice }}
+{{ $fallbackSrc := "" }}
+{{ range sort .photoWidths }}
+  {{- if and (lt . $image.Width) (le . $maxCandidateWidth) }}
     {{ $resized := $image.Resize (printf "%dx" .) }}
-    {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
+    {{ $candidates = $candidates | append (dict "src" $resized.RelPermalink "width" .) }}
+    {{ if and (eq $fallbackSrc "") (ge . $maxDisplayWidth) }}
+      {{ $fallbackSrc = $resized.RelPermalink }}
+    {{ end }}
   {{ end }}
 {{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $image.RelPermalink $image.Width }}
+
+{{ $hasTerminalCandidate := false }}
+{{ range $candidates }}
+  {{ if eq .width $maxCandidateWidth }}
+    {{ $hasTerminalCandidate = true }}
+  {{ end }}
+{{ end }}
+
+{{ if not $hasTerminalCandidate }}
+  {{ $terminalImage := $image }}
+  {{ if lt $maxCandidateWidth $image.Width }}
+    {{ $terminalImage = $image.Resize (printf "%dx" $maxCandidateWidth) }}
+  {{ end }}
+  {{ $candidates = $candidates | append (dict "src" $terminalImage.RelPermalink "width" $maxCandidateWidth) }}
+  {{ if and (eq $fallbackSrc "") (ge $maxCandidateWidth $maxDisplayWidth) }}
+    {{ $fallbackSrc = $terminalImage.RelPermalink }}
+  {{ end }}
+{{ end }}
+
+{{ if eq $fallbackSrc "" }}
+  {{ range $candidates }}
+    {{ $fallbackSrc = .src }}
+  {{ end }}
+{{ end }}
+
+{{ $srcsetEntries := slice }}
+{{ range $candidates }}
+  {{ $srcsetEntries = $srcsetEntries | append (printf "%s %dw" .src .width) }}
+{{ end }}
 
 
 <img
   {{ if $class }}class="{{ $class }}"{{ end }}
-  src="{{ $image.RelPermalink }}"
-  srcset="{{ $srcset }}"
+  src="{{ $fallbackSrc }}"
+  srcset="{{ delimit $srcsetEntries ", " }}"
   sizes="{{ $sizes }}"
   loading="{{ $loading }}"
+  alt="{{ $alt }}"
 />

--- a/layouts/posts/li.html
+++ b/layouts/posts/li.html
@@ -14,7 +14,30 @@
 <li>
   <a class="img-wrapper" href="{{ .RelPermalink }}">
     {{ if $imageResource }}
-      {{ partial "responsive-img.html" (dict "image" $imageResource "sizes" "(min-width: 768px) 400px, 98vw" "photoWidths" .Site.Params.photoWidths) }}
+      {{- /* The mobile slot is at most 768px minus 40px of container padding. */ -}}
+      {{ $mobileImageWidth := 728 }}
+      {{ if lt $imageResource.Width $mobileImageWidth }}
+        {{ $mobileImageWidth = $imageResource.Width }}
+      {{ end }}
+      {{ $desktopImageWidth := 280 }}
+      {{ if lt $imageResource.Width $desktopImageWidth }}
+        {{ $desktopImageWidth = $imageResource.Width }}
+      {{ end }}
+      {{ $heightLimitedWidth := div (add (mul 200 $imageResource.Width) (sub $imageResource.Height 1)) $imageResource.Height }}
+      {{ if lt $heightLimitedWidth $desktopImageWidth }}
+        {{ $desktopImageWidth = $heightLimitedWidth }}
+      {{ end }}
+      {{ $sizes := printf "(min-width: 768px) %dpx, calc(100vw - 4rem)" $desktopImageWidth }}
+      {{ if lt $mobileImageWidth 728 }}
+        {{ $sizes = printf "(min-width: 768px) %dpx, (min-width: %dpx) %dpx, calc(100vw - 4rem)" $desktopImageWidth (add $mobileImageWidth 40) $mobileImageWidth }}
+      {{ end }}
+      {{ partial "responsive-img.html" (dict
+        "image" $imageResource
+        "maxDisplayWidth" $mobileImageWidth
+        "photoWidths" .Site.Params.photoWidths
+        "sizes" $sizes
+        )
+      }}
     {{ end }}
   </a>
   <div>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -9,31 +9,34 @@
 {{ $image := .Page.Resources.GetMatch $srcRaw }}
 {{ $src := $image.RelPermalink }}
 
-{{ $maxWidthPixels := $image.Width }}
+{{ $requestedMaxWidthPixels := $image.Width }}
 {{ if strings.HasSuffix $maxWidth "px" }}
-  {{ $maxWidthPixels = int (replace $maxWidth "px" "") }}
+  {{ $requestedMaxWidthPixels = int (replace $maxWidth "px" "") }}
 {{ end }}
 
+{{ $containerMaxWidthPixels := $requestedMaxWidthPixels }}
 {{- /* If maxWidth is set to match the image size, but it also has a border, add
   2px to the maxWidth to account for the 1px border on either side. */ -}}
-{{ if (and $hasBorder (eq $maxWidthPixels $image.Width)) }}
-  {{ $maxWidthPixels = add $maxWidthPixels 2 }}
+{{ if (and $hasBorder (eq $containerMaxWidthPixels $image.Width)) }}
+  {{ $containerMaxWidthPixels = add $containerMaxWidthPixels 2 }}
 {{ end }}
 
-{{ $maxWidth = printf "%dpx" $maxWidthPixels }}
+{{ $maxWidth = printf "%dpx" $containerMaxWidthPixels }}
 
 {{ $containerAttrs := printf `class="img%s"%s`
   (cond (ne $align "") (printf " align-%s" $align) "")
   (cond (ne $maxWidth "") (printf ` style="max-width: %s"` $maxWidth) "") | safeHTMLAttr }}
 
-{{ $srcset := "" }}
-{{ range $.Site.Params.photoWidths }}
-  {{- if ge $image.Width . }}
-    {{ $resized := $image.Resize (printf "%dx" .) }}
-    {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-  {{ end }}
+{{- /* The container is 900px wide with 20px of padding on each side. */ -}}
+{{ $maxDisplayWidth := $requestedMaxWidthPixels }}
+{{ if gt $maxDisplayWidth 860 }}
+  {{ $maxDisplayWidth = 860 }}
 {{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $image.RelPermalink $image.Width }}
+{{ if gt $maxDisplayWidth $image.Width }}
+  {{ $maxDisplayWidth = $image.Width }}
+{{ end }}
+{{ $sizes := printf "(min-width: %dpx) %dpx, calc(100vw - 4rem)" (add $maxDisplayWidth 40) $maxDisplayWidth }}
+{{ $imgClass := cond $hasBorder "img-border" "" }}
 
 {{ if $caption }}
 <figure {{ $containerAttrs }}>
@@ -43,11 +46,14 @@
 
 {{ if $src }}
   <a href="{{ if $href }}{{ $href }}{{ else }}{{ $src }}{{ end }}">
-    <img
-      {{ if $hasBorder }}class="img-border"{{ end }}
-      sizes="(min-width: 768px) {{ if $maxWidth }}{{ $maxWidth }}{{ else }}{{ index (last 1 $.Site.Params.photoWidths) 0 }}px{{ end }}, 98vw"
-      srcset='{{ $srcset }}'
-      src="{{ $src }}" alt="{{$altText}}" loading="lazy"/>
+    {{ partial "responsive-img.html" (dict
+      "image" $image
+      "maxDisplayWidth" $maxDisplayWidth
+      "photoWidths" $.Site.Params.photoWidths
+      "sizes" $sizes
+      "alt" $altText
+      "class" $imgClass
+    ) }}
   </a>
 {{ else }}
   {{ errorf "failed to find image %s: %s" $srcRaw .Position }}


### PR DESCRIPTION
Match responsive image choices to the space images can actually occupy so Hugo does not generate and browsers do not select files that cannot improve visible quality.

Target up to 2x display density across article images and post thumbnails, including mobile layout, content-width, and thumbnail-height constraints. Avoid redundant same-size variants and keep oversized originals available through image links rather than offering them as display candidates.

Use one responsive image policy in both contexts so their sizing and fallback behavior remain consistent.